### PR TITLE
Introduce Jest for testing in server repo and properly wire up API routes

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,4 +26,5 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: yarn
+    - run: yarn test-ci
     - run: yarn build

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,5 +26,5 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: yarn
-    - run: yarn test-ci
     - run: yarn build
+    - run: yarn test-ci

--- a/jest.config.base.ts
+++ b/jest.config.base.ts
@@ -1,0 +1,2 @@
+// Jest config that should be shared across all projects
+export default {}

--- a/jest.config.base.ts
+++ b/jest.config.base.ts
@@ -1,2 +1,0 @@
-// Jest config that should be shared across all projects
-export default {}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,5 @@
+import baseConfig from './jest.config.base';
+export default {
+    ...baseConfig,
+    projects: ['<rootDir>/packages/*/jest.config.ts'],
+};

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,0 @@
-import baseConfig from './jest.config.base';
-export default {
-    ...baseConfig,
-    projects: ['<rootDir>/packages/*/jest.config.ts'],
-};

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
         "dev-live": "PORT=4000 cd packages/server && yarn start",
         "prod": "cd packages/server && yarn start",
         "generate-gql": "graphql-codegen --config codegen.yml",
-        "generate-gql-watch": "graphql-codegen --config codegen.yml --watch"
+        "generate-gql-watch": "graphql-codegen --config codegen.yml --watch",
+        "test-ci": "lerna run test --stream --concurrency 1"
     },
     "volta": {
         "node": "14.15.4",
@@ -36,11 +37,13 @@
         "@graphql-codegen/typescript": "1.21.1",
         "@graphql-codegen/typescript-generic-sdk": "^1.17.9",
         "@graphql-codegen/typescript-operations": "^1.17.15",
+        "@types/jest": "^26.0.22",
         "@typescript-eslint/eslint-plugin": "^4.12.0",
         "@typescript-eslint/parser": "^4.12.0",
         "@zerollup/ts-transform-paths": "^1.7.18",
         "eslint": "^7.17.0",
         "husky": "^5.1.1",
+        "jest": "^26.6.3",
         "lint-staged": ">=10",
         "prettier": "2.2.1",
         "scripty": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
         "@zerollup/ts-transform-paths": "^1.7.18",
         "eslint": "^7.17.0",
         "husky": "^5.1.1",
-        "jest": "^26.6.3",
         "lint-staged": ">=10",
         "prettier": "2.2.1",
         "scripty": "^2.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -76,7 +76,8 @@
         "deploy": "gh-pages -d build",
         "dev": "react-scripts start",
         "build": "react-scripts build",
-        "test": "react-scripts test",
+        "test": "react-scripts test --watchAll=false --passWithNoTests",
+        "test-watch": "react-scripts test",
         "eject": "react-scripts eject",
         "analyze": "source-map-explorer 'build/static/js/*.js'",
         "sentry": "(export SENTRY_RELEASE=$(git rev-parse --short HEAD); && node scripts/sentry-maps.js"

--- a/packages/server/.eslintrc.js
+++ b/packages/server/.eslintrc.js
@@ -2,11 +2,13 @@ const path = require('path');
 
 module.exports = {
     root: true,
+    plugins: ['unicorn'],
     parserOptions: {
         project: path.join(__dirname, './tsconfig.json'),
         sourceType: 'module',
     },
-    extends: [
-        '../../.eslintrc.json',
-    ]
+    rules: {
+        'unicorn/expiring-todo-comments': 'error',
+    },
+    extends: ['../../.eslintrc.json'],
 };

--- a/packages/server/babel.config.json
+++ b/packages/server/babel.config.json
@@ -1,0 +1,17 @@
+{
+    "presets": [
+        [
+            "@babel/preset-env",
+            {
+                "targets": {
+                    "node": "14"
+                }
+            }
+        ],
+        "@babel/preset-typescript"
+    ],
+    "babelrcRoots": [
+        ".",
+        "packages/*"
+    ]
+}

--- a/packages/server/jest.config.ts
+++ b/packages/server/jest.config.ts
@@ -1,10 +1,8 @@
 'use strict';
 
-import baseConfig from '../../jest.config.base';
 const packageName = 'server';
 
 export default {
-  ...baseConfig,
   roots: [`<rootDir>/packages/${packageName}`],
   testMatch: [`<rootDir>/packages/${packageName}/test/**/*.spec.ts`],
   moduleDirectories: ['node_modules'],
@@ -13,4 +11,3 @@ export default {
   displayName: packageName,
   rootDir: '../..',
 }
-

--- a/packages/server/jest.config.ts
+++ b/packages/server/jest.config.ts
@@ -1,0 +1,16 @@
+'use strict';
+
+import baseConfig from '../../jest.config.base';
+const packageName = 'server';
+
+export default {
+  ...baseConfig,
+  roots: [`<rootDir>/packages/${packageName}`],
+  testMatch: [`<rootDir>/packages/${packageName}/test/**/*.spec.ts`],
+  moduleDirectories: ['node_modules'],
+  modulePaths: [`<rootDir>/packages/${packageName}/src/`],
+  name: packageName,
+  displayName: packageName,
+  rootDir: '../..',
+}
+

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -78,6 +78,7 @@
         "eslint-config-prettier": "^6.15.0",
         "eslint-plugin-prettier": "^3.1.4",
         "eslint-plugin-unicorn": "^30.0.0",
+        "jest": "^26.6.3",
         "mocha": "^8.2.1",
         "nodemon": "^2.0.6",
         "pino-pretty": "^4.3.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,8 +21,8 @@
         "dev:debug": "nodemon --exec \"node -r ts-node/register --inspect-brk\" src/index.ts | pino-pretty",
         "lint": "eslint src --ext js,ts",
         "lint:fix": "eslint src --ext js,ts --fix",
-        "test": "mocha -r ts-node/register test/**/*.ts --exit",
-        "test:debug": "mocha -r ts-node/register --inspect-brk test/**/*.ts --exit"
+        "//": "Must --forceExit due to supertest not closing https://github.com/visionmedia/supertest/issues/437",
+        "test": "jest --forceExit"
     },
     "dependencies": {
         "@alch/alchemy-web3": "^0.1.18",
@@ -56,7 +56,7 @@
         "@babel/preset-typescript": "^7.12.7",
         "@types/chai": "^4.2.14",
         "@types/cookie-parser": "^1.4.2",
-        "@types/express": "^4.17.8",
+        "@types/express": "^4.17.11",
         "@types/ioredis": "^4.19.4",
         "@types/memory-cache": "^0.2.1",
         "@types/mocha": "^8.0.3",
@@ -67,6 +67,7 @@
         "@types/pino": "^6.3.4",
         "@types/pino-http": "^5.0.6",
         "@types/shelljs": "^0.8.8",
+        "@types/sinon": "^10.0.0",
         "@types/swagger-ui-express": "^4.1.2",
         "@types/ws": "^7.4.0",
         "@types/yamljs": "^0.2.31",
@@ -76,12 +77,13 @@
         "eslint": "^7.13.0",
         "eslint-config-prettier": "^6.15.0",
         "eslint-plugin-prettier": "^3.1.4",
+        "eslint-plugin-unicorn": "^30.0.0",
         "mocha": "^8.2.1",
         "nodemon": "^2.0.6",
         "pino-pretty": "^4.3.0",
         "prettier": "^2.1.2",
         "shelljs": "^0.8.4",
-        "supertest": "^6.0.1",
+        "supertest": "^6.1.3",
         "ts-node": "^9.0.0",
         "tsconfig-paths": "^3.9.0"
     }

--- a/packages/server/src/api/controllers/pools.ts
+++ b/packages/server/src/api/controllers/pools.ts
@@ -6,29 +6,16 @@ import {
   startOfHour,
   subWeeks,
 } from 'date-fns';
-import { Request, Response, Router } from 'express';
+import { Request, Router } from 'express';
 
-import { dayMs } from 'util/date'
 import { HTTPError } from 'api/util/errors';
 import { isValidEthAddress } from 'util/eth';
-import cacheMiddleware from 'api/middlewares/cache';
+import catchAsyncRoute from 'api/util/catch-async-route';
 import UV3Fetchers from 'services/uniswap-v3/fetchers';
-import wrapRequest from 'api/util/wrap-request';
 
 // TODO: move this somewhere else, maybe to the fetchers manager.
 // Will also need to namespace by network
-import { wrapWithCache, keepCachePopulated } from 'util/redis-data-cache';
-import redis from 'util/redis';
 const fetcher = UV3Fetchers.get('mainnet');
-
-// TODO: Not actually cached for now, want to fix type of wrapWithCache first
-const cached = {
-  getEthPrice: fetcher.getEthPrice,
-  getTopPools: fetcher.getTopPools,
-  getHistoricalDailyData: fetcher.getHistoricalDailyData,
-  getHistoricalHourlyData: fetcher.getHistoricalHourlyData,
-
-}
 
 // TODO: move this to utils
 const poolIdParamsSchema = Joi.object().keys({
@@ -40,8 +27,7 @@ const poolIdValidator = celebrate({
 
 // GET /ethPrice
 async function getEthPrice() {
-  const ethPrice = await cached.getEthPrice();
-  return ethPrice;
+  return fetcher.getEthPrice();
 }
 
 // GET /pools
@@ -53,9 +39,13 @@ const getTopPoolsValidator = celebrate({
   })
 });
 
-async function getTopPools(req: Request<unknown, unknown, unknown, GetTopPoolsQuery>) {
-  const { count } = req.query;
-  return cached.getTopPools(count);
+async function getTopPools(req: Request) {
+  // TODO: add override for route.get()
+  // Request<any, any, any, ParsedQs> query must be a ParsedQs
+  // We should add a union type for all validated queries
+  // or find a better TS integration with Celebrate
+  const { count }: GetTopPoolsQuery = <any> req.query;
+  return fetcher.getTopPools(count);
 }
 
 // GET /pools/:id
@@ -80,44 +70,46 @@ const getHistoricalDataValidator = celebrate({
 async function getHistoricalDailyData(req: Request<{ poolId: string }, unknown, unknown, GetHistoricalDataQuery>) {
   const { poolId } = req.params;
 
+  // TODO: Fix type
   const { startDate, endDate } = req.query;
   const start = startOfDay(startDate);
   const end = endOfDay(endDate ?? new Date());
 
-  return cached.getHistoricalDailyData(poolId, start, end);
+  return fetcher.getHistoricalDailyData(poolId, start, end);
 }
 
 // GET /pools/:id/historical/hourly
-async function getHistoricalHourlyData(req: Request<{ poolId: string }, unknown, unknown, GetHistoricalDataQuery>) {
+async function getHistoricalHourlyData(req: Request) {
   const { poolId } = req.params;
 
-  const { startDate, endDate } = req.query;
-  if (startDate < subWeeks(startDate, 1)) {
-    throw new HTTPError(400, `'startDate' must fall within the window of 1 week.`);
+  const { startDate, endDate }: GetHistoricalDataQuery = <any> req.query;
+  if (startDate < subWeeks(new Date(), 1)) {
+    throw new HTTPError(400, `"startDate" must fall within the window of 1 week.`);
   }
   const start = startOfHour(startDate);
   const end = endOfHour(endDate ?? new Date());
 
-  return cached.getHistoricalHourlyData(poolId, start, end);
+  return fetcher.getHistoricalHourlyData(poolId, start, end);
 }
 
 const route = Router();
-export default (app: Router, baseUrl: string) => {
+export default (app: Router, baseUrl: string): void => {
   app.use(baseUrl, route);
 
-  route.get('/ethPrice', wrapRequest(getEthPrice));
-  route.get('/pools', getTopPoolsValidator, wrapRequest(getTopPools));
-  route.get('/pools/:poolId', poolIdValidator, wrapRequest(getPoolOverview));
-  route.get('/pools/:poolId/historical/daily', getHistoricalDataValidator, wrapRequest(getHistoricalDailyData));
-  route.get('/pools/:poolId/historical/hourly', getHistoricalDataValidator, wrapRequest(getHistoricalHourlyData));
+  route.get('/ethPrice', catchAsyncRoute(getEthPrice));
+  route.get('/pools', getTopPoolsValidator, catchAsyncRoute(getTopPools));
+  route.get('/pools/:poolId', poolIdValidator, catchAsyncRoute(getPoolOverview));
+  route.get('/pools/:poolId/historical/daily', getHistoricalDataValidator, catchAsyncRoute(getHistoricalDailyData));
+  route.get('/pools/:poolId/historical/hourly', getHistoricalDataValidator, catchAsyncRoute(getHistoricalHourlyData));
 }
 
 // TODO: put this somewhere else
-function validateEthAddress(id: any) {
+function validateEthAddress(id: any): string {
   const isValidId = isValidEthAddress(id);
   if (!isValidId) {
-    throw new Error(`'id' must be a valid ETH address.`);
+    throw new Error('"id" must be a valid ETH address.');
   }
 
-  return id;
+  const validAddress: string = id;
+  return validAddress;
 }

--- a/packages/server/src/api/middlewares/error.handler.ts
+++ b/packages/server/src/api/middlewares/error.handler.ts
@@ -1,13 +1,32 @@
 import { Request, Response, NextFunction } from 'express';
 import { HTTPError } from 'api/util/errors';
+import { CelebrateError } from 'celebrate';
+
+const internalError = 'Internal Server Error';
 
 // eslint-disable-next-line no-unused-vars, no-shadow
 export default function errorHandler(
-    err: HTTPError,
+    err: Error | HTTPError | CelebrateError,
     req: Request,
     res: Response,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     next: NextFunction
 ): void {
-    res.status(err.status || 500).json({ error: err.message });
+    // continue
+    if (err == null) next();
+
+    if (err instanceof CelebrateError) {
+        const details = err.details.get('query') ?? err.details.get('params');
+        const error = `Validation Error: ${details?.message ?? ''}`;
+
+        res.status(400).json({ error });
+    }
+
+    // only forward errors that we intentionally created
+    if (err instanceof HTTPError) {
+        res.status(err.status).json({ error: err.message });
+    }
+
+    // all other errors should be a 500
+    res.status(500).json({ error: internalError });
 }

--- a/packages/server/src/api/util/catch-async-route.ts
+++ b/packages/server/src/api/util/catch-async-route.ts
@@ -1,0 +1,19 @@
+import { NextFunction, Request, Response, RequestHandler } from 'express';
+
+// eslint-disable-next-line no-unused-vars
+type RouteHandler = (req: Request<any, any, any, any>, res: Response) => Promise<unknown>;
+
+// Catch async route handler errors since they must be
+// TODO [express@>=5.0.0]: Remove this wrapper and call res.json directly in the function
+export default function catchAsyncRoute(
+    controllerFn: RouteHandler
+): RequestHandler {
+    return async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const response = await controllerFn(req, res);
+            return res.json(response);
+        } catch (err) {
+          next(err);
+        }
+    };
+}

--- a/packages/server/src/api/util/wrap-request.ts
+++ b/packages/server/src/api/util/wrap-request.ts
@@ -1,6 +1,7 @@
 import { Request, Response, RequestHandler } from 'express';
 
 export default function wrapRequest(
+    // eslint-ignore-next-line no-unused-vars
     controllerFn: (req: Request<any, any, any, any>, res: Response) => Promise<unknown>
 ): RequestHandler {
     return async (req: Request, res: Response) => {

--- a/packages/server/src/config/default.ts
+++ b/packages/server/src/config/default.ts
@@ -5,6 +5,9 @@ const config: AppConfig = {
     redisPort: process.env.REDIS_PORT
         ? parseInt(process.env.REDIS_PORT, 10)
         : 6379,
+    redisDataCache: {
+        enabled: true,
+    },
     port: process.env.PORT || '3001',
     requestLimit: process.env.REQUEST_LIMIT || '10kb',
     openApiSpec: '/api/v1/spec',

--- a/packages/server/src/config/index.ts
+++ b/packages/server/src/config/index.ts
@@ -1,19 +1,21 @@
 import defaultConfig from './default';
 import production from './production';
+import test from './test';
 
 import AppConfig, { Environments } from 'types/app-config';
 
 const configEnvs: Partial<{ [env in Environments]: Partial<AppConfig> }> = {
     production,
+    test,
 };
 
 const CURRENT_ENV: Environments =
-    (process.env.NODE_ENV as Environments) || 'development';
+    (process.env.NODE_ENV as Environments) ?? 'development';
 
 const activeConfig: AppConfig = Object.assign(
     {},
     defaultConfig,
-    configEnvs[CURRENT_ENV] || {}
+    configEnvs[CURRENT_ENV] ?? {}
 );
 
 export default activeConfig;

--- a/packages/server/src/config/test.ts
+++ b/packages/server/src/config/test.ts
@@ -1,0 +1,9 @@
+import AppConfig from 'types/app-config';
+
+const config: Partial<AppConfig> = {
+  redisDataCache: {
+    enabled: false,
+  }
+};
+
+export default config;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,14 +1,13 @@
 import 'common/env';
-import Server from 'common/server';
+import server from 'common/server';
 import WebsocketServer from 'ws/server';
-import routes from 'routes';
-
 import config from 'config';
+
 
 function startServer() {
     const port = parseInt(config.port);
 
-    const server = new Server().router(routes);
+    server.mountExplorer();
     server.listen(port);
 
     if (!server.httpServer) {
@@ -17,15 +16,14 @@ function startServer() {
         );
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const wsServer = new WebsocketServer(server.httpServer);
+    new WebsocketServer(server.httpServer);
 }
 
 if (require.main === module) {
     startServer();
 }
 
-export default Server;
+export default server;
 
 // Other exports for other packages
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -7,6 +7,7 @@ import config from 'config';
 function startServer() {
     const port = parseInt(config.port);
 
+    // TODO: figure out why YAML.load during mountExplorer breaks when running jest and start with tests
     server.mountExplorer();
     server.listen(port);
 

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -8,5 +8,6 @@ export default function routes(app: Application): void {
     });
     
     app.use('/api/v1/uniswap', uniswapRouter);
+
     poolsRouter(app, '/api/v1/:network');
 }

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -1,9 +1,12 @@
 import { Application } from 'express';
 import uniswapRouter from './api/controllers/uniswap';
+import poolsRouter from './api/controllers/pools';
+
 export default function routes(app: Application): void {
     app.get('/api/v1/healthcheck', (req, res) => {
         res.send('alive');
     });
     
     app.use('/api/v1/uniswap', uniswapRouter);
+    poolsRouter(app, '/api/v1/:network');
 }

--- a/packages/server/src/services/uniswap-v3/fetcher.ts
+++ b/packages/server/src/services/uniswap-v3/fetcher.ts
@@ -10,12 +10,7 @@ import {
 } from 'services/uniswap-v3/generated-types';
 import { HTTPError } from 'api/util/errors';
 import { toDateInt } from 'util/gql'
-import { wrapWithCache } from 'util/redis-data-cache';
-import BigNumber from 'bignumber.js';
-import getSdkApollo, { Sdk } from 'services/uniswap-v3/apollo-client';
-import redis from 'util/redis';
-
-const FEE_TIER_DENOMINATOR = 1000000;
+import { Sdk } from 'services/uniswap-v3/apollo-client';
 
 // The reverse of the Maybe type defined by graphql codegen
 type UnMaybe<T> = Exclude<T, null | undefined>;
@@ -86,7 +81,7 @@ export default class UniswapV3Fetcher {
   }
 
   async getTopPools(
-    count: number = 1000,
+    count = 1000,
     orderBy: keyof Pool = 'volumeUSD',
   ): Promise<GetTopPoolsResult> {
     try {
@@ -112,6 +107,8 @@ export default class UniswapV3Fetcher {
       if (pools == null || pools.length === 0) {
         throw new Error('No pools returned.');
       }
+
+      return pools;
     } catch (error) {
       throw makeSdkError(`Could not fetch top performing pools.`, error);
     }

--- a/packages/server/src/services/uniswap-v3/fetchers.ts
+++ b/packages/server/src/services/uniswap-v3/fetchers.ts
@@ -9,27 +9,25 @@ import getSdkApollo from 'services/uniswap-v3/apollo-client';
 
 // TODO: get from config
 const uri = 'http://35.197.14.14:8000/subgraphs/name/sommelier/uniswap-v3';
-const link = new HttpLink({ uri, fetch });
-const cache = new InMemoryCache();
-const client = new ApolloClient({ link, cache });
-const sdk = getSdkApollo(client);
 
 // Manages subgraph clients for multiple networks
 export default class Fetchers {
   private static instance: Fetchers;
-  private static clients: Record<string, Fetcher>;
-  private constructor() {}
+  private static clients: Record<string, Fetcher> = {};
+  private constructor() {
+    // eslint-ignore no-empty-function
+  }
 
-  public static get(network: string = 'mainnet') { // TODO: union type of valid networks
+  public static get(network = 'mainnet'): Fetcher { // TODO: union type of valid networks
     let client = Fetchers.clients[network];
-    if (client) {
+    if (!client) {
       client = Fetchers.clients[network] = Fetchers.createClient(network);
     }
 
     return client;
   }
 
-  private static createClient(network: string = 'mainnet') {
+  private static createClient(network = 'mainnet') {
     const link = new HttpLink({ uri, fetch });
     const cache = new InMemoryCache();
     const client = new ApolloClient({ link, cache });

--- a/packages/server/src/types/app-config.ts
+++ b/packages/server/src/types/app-config.ts
@@ -3,6 +3,9 @@ export type Environments = 'production' | 'development' | 'test' | 'staging';
 export default interface AppConfig {
     redisHost: string;
     redisPort: number;
+    redisDataCache: {
+        enabled: boolean,
+    }
     port: string;
     requestLimit: string;
     openApiSpec: string;

--- a/packages/server/test/api/controllers/pool.spec.ts
+++ b/packages/server/test/api/controllers/pool.spec.ts
@@ -1,0 +1,289 @@
+import { endOfDay, endOfHour, subDays, subHours, startOfDay, startOfHour } from 'date-fns';
+import supertest from 'supertest';
+
+import { app } from 'common/server';
+import UV3Fetchers from 'services/uniswap-v3/fetchers';
+
+const request = supertest(app);
+const fetcher = UV3Fetchers.get('mainnet');
+
+const validId = '0x1581d1a4f79885255e1993765ddee80c5e715181';
+
+describe('pools HTTP tests', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('GET /ethprice', () => {
+    const url = '/api/v1/mainnet/ethprice';
+    let getEthPrice;
+    beforeEach(() => {
+      getEthPrice = jest.spyOn(fetcher, 'getEthPrice');
+    });
+
+    test('calls the subgraph', async () => {
+      const expected = { ethPrice: 1 };
+      getEthPrice.mockResolvedValue(expected);
+
+      const res = await request.get(url);
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject(expected);
+
+      expect(getEthPrice).toBeCalledTimes(1);
+    });
+  });
+
+  describe('GET /pools', () => {
+    const url = '/api/v1/mainnet/pools';
+    let getTopPools;
+    beforeEach(() => {
+      getTopPools = jest.spyOn(fetcher, 'getTopPools');
+    })
+
+    test('calls the subgraph', async () => {
+      const expected = [{ id: '123' }, { id: '345' }];
+      getTopPools.mockResolvedValue(expected);
+
+      const res = await request.get(url);
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject(expected);
+
+      expect(getTopPools).toBeCalledTimes(1);
+      expect(getTopPools).toBeCalledWith(undefined);
+    });
+
+    test('calls the subgraph with count', async () => {
+      const expected = [{ id: '123' }, { id: '345' }];
+      getTopPools.mockResolvedValue(expected);
+
+      const count = 999;
+      const res = await request.get(url).query({ count });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject(expected);
+
+      expect(getTopPools).toBeCalledTimes(1);
+      expect(getTopPools).toBeCalledWith(count);
+    });
+
+    test('400s with invalid count', async () => {
+      const res = await request.get(url).query({ count: 'abcd' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Validation Error: "count" must be a number')
+    });
+  });
+
+  describe('GET /pools/:poolId', () => {
+    const url = '/api/v1/mainnet/pools';
+    let getPoolOverview;
+    beforeEach(() => {
+      getPoolOverview = jest.spyOn(fetcher, 'getPoolOverview');
+    })
+      
+    test('calls the subgraph', async () => {
+      const expected = { id: validId };
+      getPoolOverview.mockResolvedValue(expected);
+
+      const res = await request.get(`${url}/${validId}`);
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject(expected);
+
+      expect(getPoolOverview).toBeCalledTimes(1);
+      expect(getPoolOverview).toBeCalledWith(validId);
+    });
+
+    test('400s with invalid pool address', async () => {
+      const res = await request.get(`${url}/123abcd`);
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch('"id" must be a valid ETH address.');
+    });
+  })
+
+  describe('GET /pools/:poolId/historical/daily', () => {
+    let fetch;
+    beforeEach(() => {
+      fetch = jest.spyOn(fetcher, 'getHistoricalDailyData');
+    })
+
+    const getUrl = (id: string) => `/api/v1/mainnet/pools/${id}/historical/daily`;
+
+    test('calls the subgraph', async () => {
+      const expected = [{ id: validId }, { id: validId }];
+      fetch.mockResolvedValue(expected);
+
+      const endDate = new Date().getTime();
+      const startDate = subDays(new Date(endDate), 1).getTime();
+      const query = { startDate, endDate };
+      const res = await request.get(getUrl(validId)).query(query);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject(expected);
+
+      const start = startOfDay(new Date(startDate));
+      const end = endOfDay(new Date(endDate));
+      expect(fetch).toBeCalledTimes(1);
+      expect(fetch).toBeCalledWith(validId, start, end);
+    });
+
+    test('calls the subgraph with default endDate', async () => {
+      const expected = [{ id: validId }, { id: validId }];
+      fetch.mockResolvedValue(expected);
+
+      const endDate = new Date().getTime();
+      const startDate = subDays(new Date(endDate), 1).getTime();
+      const query = { startDate };
+      const res = await request.get(getUrl(validId)).query(query);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject(expected);
+
+      const start = startOfDay(new Date(startDate));
+      const end = endOfDay(new Date());
+      expect(fetch).toBeCalledTimes(1);
+      expect(fetch).toBeCalledWith(validId, start, end);
+    });
+
+    test('400s with invalid pool address', async () => {
+      const res = await request.get(getUrl('abcd'));
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch('"id" must be a valid ETH address.');
+    });
+
+    test('400s if no startDate passed', async () => {
+      const endDate = new Date().getTime();
+      const query = { endDate };
+      const res = await request.get(getUrl(validId)).query(query);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch('"startDate" is required');
+    });
+
+    test('400s if endDate is less than startDate', async () => {
+      const startDate = new Date().getTime();
+      const endDate = subDays(new Date(startDate), 1).getTime();
+      const query = { startDate, endDate };
+      const res = await request.get(getUrl(validId)).query(query);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch('"endDate" must be greater');
+    });
+
+    test('400s if startDate is invalid', async () => {
+      const startDate = 'abcd';
+      const query = { startDate };
+      const res = await request.get(getUrl(validId)).query(query);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch('"startDate" must be a valid date');
+    })
+
+    test('400s if endDate is invalid', async () => {
+      const startDate = new Date().getTime();
+      const endDate = 'watwat';
+      const query = { startDate, endDate };
+      const res = await request.get(getUrl(validId)).query(query);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch('"endDate" must be a valid date');
+    })
+  });
+
+  describe('GET /pools/:poolId/historical/hourly', () => {
+    let fetch;
+    beforeEach(() => {
+      fetch = jest.spyOn(fetcher, 'getHistoricalHourlyData');
+    })
+
+    const getUrl = (id: string) => `/api/v1/mainnet/pools/${id}/historical/hourly`;
+
+    test('calls the subgraph', async () => {
+      const expected = [{ id: validId }, { id: validId }];
+      fetch.mockResolvedValue(expected);
+
+      const endDate = new Date().getTime();
+      const startDate = subHours(new Date(endDate), 1).getTime();
+      const query = { startDate, endDate };
+      const res = await request.get(getUrl(validId)).query(query);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject(expected);
+
+      const start = startOfHour(new Date(startDate));
+      const end = endOfHour(new Date(endDate));
+      expect(fetch).toBeCalledTimes(1);
+      expect(fetch).toBeCalledWith(validId, start, end);
+    });
+
+    test('calls the subgraph with default endDate', async () => {
+      const expected = [{ id: validId }, { id: validId }];
+      fetch.mockResolvedValue(expected);
+
+      const endDate = new Date().getTime();
+      const startDate = subHours(new Date(endDate), 1).getTime();
+      const query = { startDate };
+      const res = await request.get(getUrl(validId)).query(query);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject(expected);
+
+      const start = startOfHour(new Date(startDate));
+      const end = endOfHour(new Date());
+      expect(fetch).toBeCalledTimes(1);
+      expect(fetch).toBeCalledWith(validId, start, end);
+    });
+
+    test('400s with invalid pool address', async () => {
+      const res = await request.get(getUrl('abcd'));
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch('"id" must be a valid ETH address.');
+    });
+
+    test('400s if no startDate passed', async () => {
+      const endDate = new Date().getTime();
+      const query = { endDate };
+      const res = await request.get(getUrl(validId)).query(query);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch('"startDate" is required');
+    });
+
+    test('400s if endDate is less than startDate', async () => {
+      const startDate = new Date().getTime();
+      const endDate = subDays(new Date(startDate), 1).getTime();
+      const query = { startDate, endDate };
+      const res = await request.get(getUrl(validId)).query(query);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch('"endDate" must be greater');
+    });
+
+    test('400s if startDate is greater than 1 week before now', async () => {
+      const endDate = new Date().getTime();
+      const startDate = subDays(new Date(), 8).getTime();
+      const query = { startDate, endDate };
+      const res = await request.get(getUrl(validId)).query(query);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch('"startDate" must fall within the window of 1 week.');
+    })
+
+    test('400s if startDate is invalid', async () => {
+      const startDate = 'abcd';
+      const query = { startDate };
+      const res = await request.get(getUrl(validId)).query(query);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch('"startDate" must be a valid date');
+    })
+
+    test('400s if endDate is invalid', async () => {
+      const startDate = new Date().getTime();
+      const endDate = 'watwat';
+      const query = { startDate, endDate };
+      const res = await request.get(getUrl(validId)).query(query);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch('"endDate" must be a valid date');
+    })
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,7 +81,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.13.6.tgz#11972d07db4c2317afdbf41d6feb3a730301ef4e"
   integrity sha512-VhgqKOWYVm7lQXlvbJnWOzwfAQATd2nV52koT0HZ/LdDH0m4DUDwkKYsH+IwpXb+bKPyBJzawA4I6nBKqZcpQw==
 
-"@babel/compat-data@^7.13.12", "@babel/compat-data@^7.13.8":
+"@babel/compat-data@^7.13.12", "@babel/compat-data@^7.13.15", "@babel/compat-data@^7.13.8":
   version "7.13.15"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.13.15.tgz#7e8eea42d0b64fda2b375b22d06c605222e848f4"
   integrity sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA==
@@ -151,6 +151,27 @@
     semver "7.0.0"
     source-map "^0.5.0"
 
+"@babel/core@^7.12.16":
+  version "7.13.16"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.13.16.tgz#7756ab24396cc9675f1c3fcd5b79fcce192ea96a"
+  integrity sha512-sXHpixBiWWFti0AV2Zq7avpTasr6sIAu7Y396c608541qAU2ui4a193m0KSQmfPSKFZLnQ3cvlKDOm3XkuXm3Q==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@babel/generator" "^7.13.16"
+    "@babel/helper-compilation-targets" "^7.13.16"
+    "@babel/helper-module-transforms" "^7.13.14"
+    "@babel/helpers" "^7.13.16"
+    "@babel/parser" "^7.13.16"
+    "@babel/template" "^7.12.13"
+    "@babel/traverse" "^7.13.15"
+    "@babel/types" "^7.13.16"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    semver "^6.3.0"
+    source-map "^0.5.0"
+
 "@babel/eslint-parser@^7.12.1":
   version "7.13.4"
   resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.13.4.tgz#dd9df3c70f44d2fb5a6519e8e10ca06c67dca43a"
@@ -159,6 +180,15 @@
     eslint-scope "5.1.0"
     eslint-visitor-keys "^1.3.0"
     semver "7.0.0"
+
+"@babel/eslint-parser@^7.12.16":
+  version "7.13.14"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.13.14.tgz#f80fd23bdd839537221914cb5d17720a5ea6ba3a"
+  integrity sha512-I0HweR36D73Ibn/FfrRDMKlMqJHFwidIUgYdMpH+aXYuQC+waq59YaJ6t9e9N36axJ82v1jR041wwqDrDXEwRA==
+  dependencies:
+    eslint-scope "^5.1.0"
+    eslint-visitor-keys "^1.3.0"
+    semver "^6.3.0"
 
 "@babel/generator@^7.12.1", "@babel/generator@^7.13.0":
   version "7.13.0"
@@ -175,6 +205,15 @@
   integrity sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==
   dependencies:
     "@babel/types" "^7.13.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.13.16":
+  version "7.13.16"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.13.16.tgz#0befc287031a201d84cdfc173b46b320ae472d14"
+  integrity sha512-grBBR75UnKOcUWMp8WoDxNsWCFl//XCK6HWTrBQKTr5SV9f5g0pNOjdyzi/DTBv12S9GnYPInIXQBTky7OXEMg==
+  dependencies:
+    "@babel/types" "^7.13.16"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -209,6 +248,16 @@
   integrity sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==
   dependencies:
     "@babel/compat-data" "^7.13.12"
+    "@babel/helper-validator-option" "^7.12.17"
+    browserslist "^4.14.5"
+    semver "^6.3.0"
+
+"@babel/helper-compilation-targets@^7.13.16":
+  version "7.13.16"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz#6e91dccf15e3f43e5556dffe32d860109887563c"
+  integrity sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==
+  dependencies:
+    "@babel/compat-data" "^7.13.15"
     "@babel/helper-validator-option" "^7.12.17"
     browserslist "^4.14.5"
     semver "^6.3.0"
@@ -441,6 +490,15 @@
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
 
+"@babel/helpers@^7.13.16":
+  version "7.13.17"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.13.17.tgz#b497c7a00e9719d5b613b8982bda6ed3ee94caf6"
+  integrity sha512-Eal4Gce4kGijo1/TGJdqp3WuhllaMLSrW6XcL0ulyUAQOuxHcCafZE8KHg9857gcTehsm/v7RcOx2+jp0Ryjsg==
+  dependencies:
+    "@babel/template" "^7.12.13"
+    "@babel/traverse" "^7.13.17"
+    "@babel/types" "^7.13.17"
+
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.12.13.tgz#8ab538393e00370b26271b01fa08f7f27f2e795c"
@@ -464,6 +522,11 @@
   version "7.13.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.4.tgz#340211b0da94a351a6f10e63671fa727333d13ab"
   integrity sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA==
+
+"@babel/parser@^7.13.16":
+  version "7.13.16"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.16.tgz#0f18179b0448e6939b1f3f5c4c355a3a9bcdfd37"
+  integrity sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw==
 
 "@babel/plugin-proposal-async-generator-functions@^7.12.1", "@babel/plugin-proposal-async-generator-functions@^7.13.5":
   version "7.13.5"
@@ -1408,6 +1471,20 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
+"@babel/traverse@^7.13.17":
+  version "7.13.17"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.13.17.tgz#c85415e0c7d50ac053d758baec98b28b2ecfeea3"
+  integrity sha512-BMnZn0R+X6ayqm3C3To7o1j7Q020gWdqdyP50KEoVqaCO2c/Im7sYZSmVgvefp8TTMQ+9CtwuBp0Z1CZ8V3Pvg==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@babel/generator" "^7.13.16"
+    "@babel/helper-function-name" "^7.12.13"
+    "@babel/helper-split-export-declaration" "^7.12.13"
+    "@babel/parser" "^7.13.16"
+    "@babel/types" "^7.13.17"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.13.tgz#8be1aa8f2c876da11a9cf650c0ecf656913ad611"
@@ -1433,6 +1510,14 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
     lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.13.16", "@babel/types@^7.13.17":
+  version "7.13.17"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.17.tgz#48010a115c9fba7588b4437dd68c9469012b38b4"
+  integrity sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.12.11"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -3630,6 +3715,13 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@sinonjs/fake-timers@^7.0.4":
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-7.0.5.tgz#558a7f8145a01366c44b3dcbdd7172c05c461564"
+  integrity sha512-fUt6b15bjV/VW93UP5opNXJxdwZSbK1EdiwnhN7XrQrcpaOhMJpZ/CjwFpM3THpxwA+YviBUJKSuEqKlCK5alw==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
 "@surma/rollup-plugin-off-main-thread@^1.1.1":
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-1.4.2.tgz#e6786b6af5799f82f7ab3a82e53f6182d2b91a58"
@@ -3932,7 +4024,7 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
 
-"@types/express@*", "@types/express@^4.17.8":
+"@types/express@*", "@types/express@^4.17.11":
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.11.tgz#debe3caa6f8e5fcda96b47bd54e2f40c4ee59545"
   integrity sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==
@@ -4009,6 +4101,14 @@
   version "26.0.20"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.20.tgz#cd2f2702ecf69e86b586e1f5223a60e454056307"
   integrity sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
+
+"@types/jest@^26.0.22":
+  version "26.0.22"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.22.tgz#8308a1debdf1b807aa47be2838acdcd91e88fbe6"
+  integrity sha512-eeWwWjlqxvBxc4oQdkueW5OF/gtfSceKk4OnOAGlUSwS/liBRtZppbJuz1YkgbrbfGOoeBHun9fOvXnjNwrSOw==
   dependencies:
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
@@ -4313,6 +4413,13 @@
   dependencies:
     "@types/glob" "*"
     "@types/node" "*"
+
+"@types/sinon@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.0.tgz#eecc3847af03d45ffe53d55aaaaf6ecb28b5e584"
+  integrity sha512-jDZ55oCKxqlDmoTBBbBBEx+N8ZraUVhggMZ9T5t+6/Dh8/4NiOjSUfpLrPiEwxQDlAe3wpAkoXhWvE6LibtsMQ==
+  dependencies:
+    "@sinonjs/fake-timers" "^7.0.4"
 
 "@types/sonic-boom@*":
   version "0.7.0"
@@ -6657,6 +6764,11 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
+ci-info@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.1.1.tgz#9a32fcefdf7bcdb6f0a7e1c0f8098ec57897b80a"
+  integrity sha512-kdRWLBIJwdsYJWYJFtAFFYxybguqeF91qpZaggjG5Nf8QKdizFG2hjqvaTXbxFIcYbSaD74KpAXv6BSm17DHEQ==
+
 cids@^0.7.1:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/cids/-/cids-0.7.5.tgz#60a08138a99bfb69b6be4ceb63bfef7a396b28b2"
@@ -6707,6 +6819,13 @@ clean-css@^4.2.3:
   integrity sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==
   dependencies:
     source-map "~0.6.0"
+
+clean-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clean-regexp/-/clean-regexp-1.0.0.tgz#8df7c7aae51fd36874e8f8d05b9180bc11a3fed7"
+  integrity sha1-jffHquUf02h06PjQW5GAvBGj/tc=
+  dependencies:
+    escape-string-regexp "^1.0.5"
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -8832,6 +8951,25 @@ eslint-plugin-testing-library@^3.9.2:
   dependencies:
     "@typescript-eslint/experimental-utils" "^3.10.1"
 
+eslint-plugin-unicorn@^30.0.0:
+  version "30.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-30.0.0.tgz#45d3d138f444eff527e8c00f7a9299bcfcb5051b"
+  integrity sha512-ZKbE48Ep99z/3geLpkBfv+jNrzr2k7bLqCC/RfZOekZzAvn2/ECDE/d8zGdW1YxHmIC9pevQvm8Pl89v9GEIVw==
+  dependencies:
+    ci-info "^3.1.1"
+    clean-regexp "^1.0.0"
+    eslint-template-visitor "^2.3.2"
+    eslint-utils "^2.1.0"
+    eslint-visitor-keys "^2.0.0"
+    import-modules "^2.1.0"
+    lodash "^4.17.21"
+    pluralize "^8.0.0"
+    read-pkg-up "^7.0.1"
+    regexp-tree "^0.1.23"
+    reserved-words "^0.1.2"
+    safe-regex "^2.1.1"
+    semver "^7.3.5"
+
 eslint-scope@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.0.tgz#d0f971dfe59c69e0cada684b23d49dbf82600ce5"
@@ -8848,13 +8986,24 @@ eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@^5.0.0, eslint-scope@^5.1.1:
+eslint-scope@^5.0.0, eslint-scope@^5.1.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
+
+eslint-template-visitor@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/eslint-template-visitor/-/eslint-template-visitor-2.3.2.tgz#b52f96ff311e773a345d79053ccc78275bbc463d"
+  integrity sha512-3ydhqFpuV7x1M9EK52BPNj6V0Kwu0KKkcIAfpUhwHbR8ocRln/oUHgfxQupY8O1h4Qv/POHDumb/BwwNfxbtnA==
+  dependencies:
+    "@babel/core" "^7.12.16"
+    "@babel/eslint-parser" "^7.12.16"
+    eslint-visitor-keys "^2.0.0"
+    esquery "^1.3.1"
+    multimap "^1.1.0"
 
 eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   version "2.1.0"
@@ -8946,7 +9095,7 @@ esprima@~1.0.4:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.0.4.tgz#9f557e08fc3b4d26ece9dd34f8fbf476b62585ad"
   integrity sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=
 
-esquery@^1.4.0:
+esquery@^1.3.1, esquery@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
   integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
@@ -11104,6 +11253,11 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
+import-modules@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-modules/-/import-modules-2.1.0.tgz#abe7df297cb6c1f19b57246eb8b8bd9664b6d8c2"
+  integrity sha512-8HEWcnkbGpovH9yInoisxaSoIg9Brbul+Ju3Kqe2UsYDUBJD/iQjSgEj0zPcTDPKfPp2fs5xlv1i+JSye/m1/A==
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -11925,7 +12079,7 @@ jest-circus@26.6.0:
     stack-utils "^2.0.2"
     throat "^5.0.0"
 
-jest-cli@^26.6.0:
+jest-cli@^26.6.0, jest-cli@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-26.6.3.tgz#43117cfef24bc4cd691a174a8796a532e135e92a"
   integrity sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
@@ -12323,6 +12477,15 @@ jest@26.6.0:
     "@jest/core" "^26.6.0"
     import-local "^3.0.2"
     jest-cli "^26.6.0"
+
+jest@^26.6.3:
+  version "26.6.3"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-26.6.3.tgz#40e8fdbe48f00dfa1f0ce8121ca74b88ac9148ef"
+  integrity sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
+  dependencies:
+    "@jest/core" "^26.6.3"
+    import-local "^3.0.2"
+    jest-cli "^26.6.3"
 
 jmespath@^0.15.0:
   version "0.15.0"
@@ -13103,7 +13266,7 @@ lodash.zipobject@^4.1.3:
   resolved "https://registry.yarnpkg.com/lodash.zipobject/-/lodash.zipobject-4.1.3.tgz#b399f5aba8ff62a746f6979bf20b214f964dbef8"
   integrity sha1-s5n1q6j/YqdG9peb8gshT5ZNvvg=
 
-lodash@4.17.x, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5, lodash@^4.2.1, lodash@~4.17.10, lodash@~4.17.20, lodash@~4.17.4:
+lodash@4.17.x, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5, lodash@^4.2.1, lodash@~4.17.10, lodash@~4.17.20, lodash@~4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -13882,6 +14045,11 @@ multihashes@^0.4.15, multihashes@~0.4.15:
     buffer "^5.5.0"
     multibase "^0.7.0"
     varint "^5.0.0"
+
+multimap@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/multimap/-/multimap-1.1.0.tgz#5263febc085a1791c33b59bb3afc6a76a2a10ca8"
+  integrity sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==
 
 multimatch@^3.0.0:
   version "3.0.0"
@@ -15130,6 +15298,11 @@ please-upgrade-node@^3.2.0:
   integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
   dependencies:
     semver-compare "^1.0.0"
+
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
 
 pngjs@^3.3.0:
   version "3.4.0"
@@ -16937,6 +17110,11 @@ regex-parser@^2.2.11:
   resolved "https://registry.yarnpkg.com/regex-parser/-/regex-parser-2.2.11.tgz#3b37ec9049e19479806e878cabe7c1ca83ccfe58"
   integrity sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==
 
+regexp-tree@^0.1.23, regexp-tree@~0.1.1:
+  version "0.1.23"
+  resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.23.tgz#8a8ce1cc5e971acef62213a7ecdb1f6e18a1f1b2"
+  integrity sha512-+7HWfb4Bvu8Rs2eQTUIpX9I/PlQkYOuTNbRpKLJlQpSgwSkzFYh+pUj0gtvglnOZLKB6YgnIgRuJ2/IlpL48qw==
+
 regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz#7ef352ae8d159e758c0eadca6f8fcb4eef07be26"
@@ -17142,6 +17320,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reserved-words@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.2.tgz#00a0940f98cd501aeaaac316411d9adc52b31ab1"
+  integrity sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=
 
 resize-observer-polyfill@^1.5.0:
   version "1.5.1"
@@ -17445,6 +17628,13 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
+safe-regex@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-2.1.1.tgz#f7128f00d056e2fe5c11e81a1324dd974aadced2"
+  integrity sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==
+  dependencies:
+    regexp-tree "~0.1.1"
+
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
@@ -17656,6 +17846,13 @@ semver@^7.2.1, semver@^7.3.2:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -18643,7 +18840,7 @@ superagent@^6.1.0:
     readable-stream "^3.6.0"
     semver "^7.3.2"
 
-supertest@^6.0.1:
+supertest@^6.1.3:
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/supertest/-/supertest-6.1.3.tgz#3f49ea964514c206c334073e8dc4e70519c7403f"
   integrity sha512-v2NVRyP73XDewKb65adz+yug1XMtmvij63qIWHZzSX8tp6wiq6xBLUy4SUAd2NII6wIipOmHT/FD9eicpJwdgQ==


### PR DESCRIPTION
- Introduces Jest for testing
- Properly wires up the new routes to `/api/v1/:network` (network switching coming soon
- Adds complete test suite for pools.ts routes
- Tests run as part of Github Action