### PR TITLE
Support multiple networks on V3 Uniswap Routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "prod": "cd packages/server && yarn start",
         "generate-gql": "graphql-codegen --config codegen.yml",
         "generate-gql-watch": "graphql-codegen --config codegen.yml --watch",
-        "test-ci": "lerna run test --stream --concurrency 1"
+        "test-ci": "lerna run test --stream --concurrency 1",
+        "test": "jest --forceExit"
     },
     "volta": {
         "node": "14.15.4",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -22,7 +22,7 @@
         "lint": "eslint src --ext js,ts",
         "lint:fix": "eslint src --ext js,ts --fix",
         "//": "Must --forceExit due to supertest not closing https://github.com/visionmedia/supertest/issues/437",
-        "test": "jest --forceExit"
+        "test": "NODE_ENV=test jest --forceExit"
     },
     "dependencies": {
         "@alch/alchemy-web3": "^0.1.18",

--- a/packages/server/src/api/controllers/pools.ts
+++ b/packages/server/src/api/controllers/pools.ts
@@ -11,11 +11,11 @@ import { Request, Router } from 'express';
 import { HTTPError } from 'api/util/errors';
 import { isValidEthAddress } from 'util/eth';
 import catchAsyncRoute from 'api/util/catch-async-route';
-import UV3Fetchers from 'services/uniswap-v3/fetchers';
+import { UniswapV3Fetchers } from 'services/uniswap-v3/fetchers';
 
 // TODO: move this somewhere else, maybe to the fetchers manager.
 // Will also need to namespace by network
-const fetcher = UV3Fetchers.get('mainnet');
+const fetcher = UniswapV3Fetchers.get('mainnet');
 
 // TODO: move this to utils
 const poolIdParamsSchema = Joi.object().keys({

--- a/packages/server/src/api/middlewares/error.handler.ts
+++ b/packages/server/src/api/middlewares/error.handler.ts
@@ -31,6 +31,5 @@ export default function errorHandler(
     res.status(500).json({ error: internalError });
 
     // let us know about these 500s
-    // TODO: log stack trace
-    console.error(err.message);
+    console.warn(`Internal Server Error: ${err.stack ?? err.message}`);
 }

--- a/packages/server/src/api/middlewares/error.handler.ts
+++ b/packages/server/src/api/middlewares/error.handler.ts
@@ -29,4 +29,8 @@ export default function errorHandler(
 
     // all other errors should be a 500
     res.status(500).json({ error: internalError });
+
+    // let us know about these 500s
+    // TODO: log stack trace
+    console.error(err.message);
 }

--- a/packages/server/src/config/default.ts
+++ b/packages/server/src/config/default.ts
@@ -5,8 +5,19 @@ const config: AppConfig = {
     redisPort: process.env.REDIS_PORT
         ? parseInt(process.env.REDIS_PORT, 10)
         : 6379,
-    redisDataCache: {
+    memoizerRedis: {
         enabled: true,
+    },
+    uniswap: {
+        v3: {
+            networks: {
+                mainnet: 'http://35.197.14.14:8000/subgraphs/name/sommelier/uniswap-v3',
+                rinkeby: 'http://35.197.14.14:8000/subgraphs/name/sommelier/uniswap-v3',
+                goerli: 'http://35.197.14.14:8000/subgraphs/name/sommelier/uniswap-v3',
+                ropsten: 'http://35.197.14.14:8000/subgraphs/name/sommelier/uniswap-v3',
+                kovan: 'http://35.197.14.14:8000/subgraphs/name/sommelier/uniswap-v3',
+            }
+        }
     },
     port: process.env.PORT || '3001',
     requestLimit: process.env.REQUEST_LIMIT || '10kb',

--- a/packages/server/src/config/test.ts
+++ b/packages/server/src/config/test.ts
@@ -1,7 +1,7 @@
 import AppConfig from 'types/app-config';
 
 const config: Partial<AppConfig> = {
-  redisDataCache: {
+  memoizerRedis: {
     enabled: false,
   }
 };

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -9,5 +9,5 @@ export default function routes(app: Application): void {
     
     app.use('/api/v1/uniswap', uniswapRouter);
 
-    poolsRouter(app, '/api/v1/:network');
+    poolsRouter(app, '/api/v1');
 }

--- a/packages/server/src/services/uniswap-v3/fetcher-memoized.ts
+++ b/packages/server/src/services/uniswap-v3/fetcher-memoized.ts
@@ -1,3 +1,4 @@
+import { dayMs, hourMs, minuteMs } from 'util/date';
 import { Pool } from 'services/uniswap-v3/generated-types';
 import {
   GetPoolDailyDataResult,
@@ -10,6 +11,16 @@ import {
 import memoizer from 'util/memoizer-redis';
 import redis from 'util/redis';
 
+// TODO: Move this to config and review TTLs
+const memoConfig = {
+  getEthPrice: { ttl: minuteMs * 1 },
+  getPoolOverview: { ttl: hourMs * 6 },
+  getTopPools: { ttl: minuteMs * 5 },
+  getHistoricalDailyData: { ttl: hourMs * 1 },
+  getHistoricalHourlyData: { ttl: hourMs * 1 },
+};
+
+// Proxy for UniswapV3Fetcher where functions are memoized
 export class UniswapV3FetcherMemoized implements UniswapFetcher {
   private memoize: ReturnType<typeof memoizer>;
   private fetcher: UniswapV3Fetcher;
@@ -19,25 +30,46 @@ export class UniswapV3FetcherMemoized implements UniswapFetcher {
     this.fetcher = fetcher;
   }
 
+  // TODO: figure out how to DRY this up and keep types
   getEthPrice(blockNumber?: number): Promise<{ ethPrice: number }> {
-    const fn = this.memoize(this.fetcher.getEthPrice.bind(this.fetcher));
-    return fn();
+    const config = memoConfig.getEthPrice;
+    const fn = this.memoize(this.fetcher.getEthPrice.bind(this.fetcher), config);
+    return fn(blockNumber);
   }
 
   getPoolOverview(poolId: string, blockNumber?: number): Promise<GetPoolOverviewResult> {
-    const fn = this.memoize(this.fetcher.getPoolOverview.bind(this.fetcher));
-    return fn();
+    const config = memoConfig.getPoolOverview;
+    const fn = this.memoize(this.fetcher.getPoolOverview.bind(this.fetcher), config);
+    return fn(poolId, blockNumber);
   }
+
   getTopPools(count: number, orderBy: keyof Pool): Promise<GetTopPoolsResult> {
-    const fn = this.memoize(this.fetcher.getTopPools.bind(this.fetcher));
-    return fn();
+    const config = memoConfig.getTopPools;
+    const fn = this.memoize(this.fetcher.getTopPools.bind(this.fetcher), config);
+    return fn(count, orderBy);
   }
+
+  // not memoized
   getPoolDailyData(poolId: string, start: Date, end: Date): Promise<GetPoolDailyDataResult> {
-    const fn = this.memoize(this.fetcher.getPoolDailyData.bind(this.fetcher));
-    return fn();
+    const fn = this.fetcher.getPoolDailyData.bind(this.fetcher);
+    return fn(poolId, start, end);
   }
+
+  // not memoized
   getPoolHourlyData(poolId: string, start: Date, end: Date): Promise<GetPoolHourlyDataResult> {
-    const fn = this.memoize(this.fetcher.getPoolHourlyData.bind(this.fetcher));
-    return fn();
+    const fn = this.fetcher.getPoolHourlyData.bind(this.fetcher);
+    return fn(poolId, start, end);
+  }
+
+  getHistoricalDailyData(poolId: string, start: Date, end: Date): Promise<GetPoolDailyDataResult> {
+    const config = memoConfig.getHistoricalDailyData;
+    const fn = this.memoize(this.fetcher.getHistoricalDailyData.bind(this.fetcher), config);
+    return fn(poolId, start, end);
+  }
+
+  getHistoricalHourlyData(poolId: string, start: Date, end: Date): Promise<GetPoolHourlyDataResult> {
+    const config = memoConfig.getHistoricalHourlyData;
+    const fn = this.memoize(this.fetcher.getHistoricalHourlyData.bind(this.fetcher), config);
+    return fn(poolId, start, end);
   }
 }

--- a/packages/server/src/services/uniswap-v3/fetcher-memoized.ts
+++ b/packages/server/src/services/uniswap-v3/fetcher-memoized.ts
@@ -1,0 +1,48 @@
+import { Pool } from 'services/uniswap-v3/generated-types';
+import {
+  GetPoolDailyDataResult,
+  GetPoolHourlyDataResult,
+  GetPoolOverviewResult,
+  GetTopPoolsResult,
+  UniswapFetcher,
+  UniswapV3Fetcher
+} from 'services/uniswap-v3/fetcher';
+import memoizer from 'util/memoizer-redis';
+import redis from 'util/redis';
+
+type Keys = keyof UniswapV3Fetcher;
+type MemoizedFunction<T> = (...args: Array<any>) => T;
+
+export class UniswapV3FetcherMemoized implements UniswapFetcher {
+  private memoize: ReturnType<typeof memoizer>;
+  private fetcher: UniswapV3Fetcher;
+  private memoized: Map<Keys, MemoizedFunction<UniswapV3Fetcher[Keys]>>;
+
+  constructor(fetcher: UniswapV3Fetcher, network: string) {
+    this.memoize = memoizer(redis, { keyPrefix: network });
+    this.fetcher = fetcher;
+    this.memoized = new Map();
+  }
+
+  getEthPrice(blockNumber?: number): Promise<{ ethPrice: number }> {
+    const fn = this.memoize(this.fetcher.getEthPrice.bind(this.fetcher));
+    return fn();
+  }
+
+  getPoolOverview(poolId: string, blockNumber?: number): Promise<GetPoolOverviewResult> {
+    const fn = this.memoize(this.fetcher.getPoolOverview.bind(this.fetcher));
+    return fn();
+  }
+  getTopPools(count: number, orderBy: keyof Pool): Promise<GetTopPoolsResult> {
+    const fn = this.memoize(this.fetcher.getTopPools.bind(this.fetcher));
+    return fn();
+  }
+  getPoolDailyData(poolId: string, start: Date, end: Date): Promise<GetPoolDailyDataResult> {
+    const fn = this.memoize(this.fetcher.getPoolDailyData.bind(this.fetcher));
+    return fn();
+  }
+  getPoolHourlyData(poolId: string, start: Date, end: Date): Promise<GetPoolHourlyDataResult> {
+    const fn = this.memoize(this.fetcher.getPoolHourlyData.bind(this.fetcher));
+    return fn();
+  }
+}

--- a/packages/server/src/services/uniswap-v3/fetcher-memoized.ts
+++ b/packages/server/src/services/uniswap-v3/fetcher-memoized.ts
@@ -10,18 +10,13 @@ import {
 import memoizer from 'util/memoizer-redis';
 import redis from 'util/redis';
 
-type Keys = keyof UniswapV3Fetcher;
-type MemoizedFunction<T> = (...args: Array<any>) => T;
-
 export class UniswapV3FetcherMemoized implements UniswapFetcher {
   private memoize: ReturnType<typeof memoizer>;
   private fetcher: UniswapV3Fetcher;
-  private memoized: Map<Keys, MemoizedFunction<UniswapV3Fetcher[Keys]>>;
 
   constructor(fetcher: UniswapV3Fetcher, network: string) {
     this.memoize = memoizer(redis, { keyPrefix: network });
     this.fetcher = fetcher;
-    this.memoized = new Map();
   }
 
   getEthPrice(blockNumber?: number): Promise<{ ethPrice: number }> {

--- a/packages/server/src/services/uniswap-v3/fetcher.ts
+++ b/packages/server/src/services/uniswap-v3/fetcher.ts
@@ -17,10 +17,10 @@ type UnMaybe<T> = Exclude<T, null | undefined>;
 
 // Fn return types derived from generated types
 // Type = { ...pool, volumeUSD: string, feesUSD: string }
-type GetPoolOverviewResult = UnMaybe<GetPoolOverviewQuery['pool']>;
-type GetTopPoolsResult = UnMaybe<GetPoolsOverviewQuery['pools']>;
-type GetPoolDailyDataResult = UnMaybe<GetPoolDailyDataQuery['poolDayDatas']>;
-type GetPoolHourlyDataResult = UnMaybe<GetPoolHourlyDataQuery['poolHourDatas']>;
+export type GetPoolOverviewResult = UnMaybe<GetPoolOverviewQuery['pool']>;
+export type GetTopPoolsResult = UnMaybe<GetPoolsOverviewQuery['pools']>;
+export type GetPoolDailyDataResult = UnMaybe<GetPoolDailyDataQuery['poolDayDatas']>;
+export type GetPoolHourlyDataResult = UnMaybe<GetPoolHourlyDataQuery['poolHourDatas']>;
 
 export interface UniswapFetcher {
   getEthPrice(blockNumber?: number): Promise<({ ethPrice: number })>;

--- a/packages/server/src/services/uniswap-v3/fetcher.ts
+++ b/packages/server/src/services/uniswap-v3/fetcher.ts
@@ -22,7 +22,15 @@ type GetTopPoolsResult = UnMaybe<GetPoolsOverviewQuery['pools']>;
 type GetPoolDailyDataResult = UnMaybe<GetPoolDailyDataQuery['poolDayDatas']>;
 type GetPoolHourlyDataResult = UnMaybe<GetPoolHourlyDataQuery['poolHourDatas']>;
 
-export default class UniswapV3Fetcher {
+export interface UniswapFetcher {
+  getEthPrice(blockNumber?: number): Promise<({ ethPrice: number })>;
+  getPoolOverview(poolId: string, blockNumber?: number): Promise<GetPoolOverviewResult>;
+  getTopPools(count: number, orderBy: keyof Pool): Promise<GetTopPoolsResult>;
+  getPoolDailyData(poolId: string, start: Date, end: Date): Promise<GetPoolDailyDataResult>;
+  getPoolHourlyData(poolId: string, start: Date, end: Date): Promise<GetPoolHourlyDataResult>;
+}
+
+export class UniswapV3Fetcher {
   sdk: Sdk;
 
   constructor(sdk: Sdk) {
@@ -93,24 +101,6 @@ export default class UniswapV3Fetcher {
       return pools;
     } catch (error) {
       throw makeSdkError(`Could not fetch top pool.`, error);
-    }
-  }
-
-  async getCurrentTopPerformingPools(count = 100) {
-    try {
-      const { pools } = await this.sdk.getTopPools({
-        first: count,
-        orderDirection: 'desc',
-        orderBy: 'volumeUSD',
-      });
-
-      if (pools == null || pools.length === 0) {
-        throw new Error('No pools returned.');
-      }
-
-      return pools;
-    } catch (error) {
-      throw makeSdkError(`Could not fetch top performing pools.`, error);
     }
   }
 

--- a/packages/server/src/services/uniswap-v3/fetcher.ts
+++ b/packages/server/src/services/uniswap-v3/fetcher.ts
@@ -28,6 +28,8 @@ export interface UniswapFetcher {
   getTopPools(count: number, orderBy: keyof Pool): Promise<GetTopPoolsResult>;
   getPoolDailyData(poolId: string, start: Date, end: Date): Promise<GetPoolDailyDataResult>;
   getPoolHourlyData(poolId: string, start: Date, end: Date): Promise<GetPoolHourlyDataResult>;
+  getHistoricalDailyData(poolId: string, start: Date, end: Date): Promise<GetPoolDailyDataResult>;
+  getHistoricalHourlyData(poolId: string, start: Date, end: Date): Promise<GetPoolDailyHourlyResult>;
 }
 
 export class UniswapV3Fetcher {

--- a/packages/server/src/services/uniswap-v3/fetchers.ts
+++ b/packages/server/src/services/uniswap-v3/fetchers.ts
@@ -4,35 +4,45 @@ import {
     InMemoryCache,
 } from '@apollo/client/core';
 import fetch from 'cross-fetch';
-import { UniswapV3Fetcher } from 'services/uniswap-v3/fetcher';
+
+import { UniswapV3Fetcher, UniswapV3FetcherMemoized } from 'services/uniswap-v3';
+import appConfig from 'config';
 import getSdkApollo from 'services/uniswap-v3/apollo-client';
 
-// TODO: get from config
-const uri = 'http://35.197.14.14:8000/subgraphs/name/sommelier/uniswap-v3';
+const config = appConfig.uniswap.v3.networks;
 
 // Manages subgraph clients for multiple networks
 export class UniswapV3Fetchers {
   private static instance: UniswapV3Fetchers;
-  private static clients: Record<string, UniswapV3Fetcher> = {};
+  private static clients: Map<keyof config, UniswapV3Fetcher> = new Map();
   private constructor() {
     // eslint-ignore no-empty-function
   }
 
   public static get(network = 'mainnet'): UniswapV3Fetcher { // TODO: union type of valid networks
-    let client = UniswapV3Fetchers.clients[network];
+    let client = UniswapV3Fetchers.clients.get(network);
     if (!client) {
-      client = UniswapV3Fetchers.clients[network] = UniswapV3Fetchers.createClient(network);
+      client = UniswapV3Fetchers.createClient(network);
+      UniswapV3Fetchers.clients.set(network, client);
     }
 
     return client;
   }
 
   private static createClient(network = 'mainnet') {
+    const uri = getUri(network);
+    if (uri == null) {
+      throw new Error(`${network} is an invalid network.`)
+    }
     const link = new HttpLink({ uri, fetch });
     const cache = new InMemoryCache();
     const client = new ApolloClient({ link, cache });
     const sdk = getSdkApollo(client);
 
-    return new UniswapV3Fetcher(sdk);
+    return new UniswapV3FetcherMemoized(new UniswapV3Fetcher(sdk), network);
   }
+}
+
+export function getUri(network: string): string {
+  return config[network];
 }

--- a/packages/server/src/services/uniswap-v3/fetchers.ts
+++ b/packages/server/src/services/uniswap-v3/fetchers.ts
@@ -4,24 +4,24 @@ import {
     InMemoryCache,
 } from '@apollo/client/core';
 import fetch from 'cross-fetch';
-import Fetcher from 'services/uniswap-v3/fetcher';
+import { UniswapV3Fetcher } from 'services/uniswap-v3/fetcher';
 import getSdkApollo from 'services/uniswap-v3/apollo-client';
 
 // TODO: get from config
 const uri = 'http://35.197.14.14:8000/subgraphs/name/sommelier/uniswap-v3';
 
 // Manages subgraph clients for multiple networks
-export default class Fetchers {
-  private static instance: Fetchers;
-  private static clients: Record<string, Fetcher> = {};
+export class UniswapV3Fetchers {
+  private static instance: UniswapV3Fetchers;
+  private static clients: Record<string, UniswapV3Fetcher> = {};
   private constructor() {
     // eslint-ignore no-empty-function
   }
 
-  public static get(network = 'mainnet'): Fetcher { // TODO: union type of valid networks
-    let client = Fetchers.clients[network];
+  public static get(network = 'mainnet'): UniswapV3Fetcher { // TODO: union type of valid networks
+    let client = UniswapV3Fetchers.clients[network];
     if (!client) {
-      client = Fetchers.clients[network] = Fetchers.createClient(network);
+      client = UniswapV3Fetchers.clients[network] = UniswapV3Fetchers.createClient(network);
     }
 
     return client;
@@ -33,6 +33,6 @@ export default class Fetchers {
     const client = new ApolloClient({ link, cache });
     const sdk = getSdkApollo(client);
 
-    return new Fetcher(sdk);
+    return new UniswapV3Fetcher(sdk);
   }
 }

--- a/packages/server/src/services/uniswap-v3/index.ts
+++ b/packages/server/src/services/uniswap-v3/index.ts
@@ -1,3 +1,4 @@
 export * from './fetcher';
 export * from './fetchers';
+export * from './fetcher-memoized';
 export * from './generated-types'; 

--- a/packages/server/src/services/uniswap-v3/index.ts
+++ b/packages/server/src/services/uniswap-v3/index.ts
@@ -1,0 +1,3 @@
+export * from './fetcher';
+export * from './fetchers';
+export * from './generated-types'; 

--- a/packages/server/src/types/app-config.ts
+++ b/packages/server/src/types/app-config.ts
@@ -3,8 +3,19 @@ export type Environments = 'production' | 'development' | 'test' | 'staging';
 export default interface AppConfig {
     redisHost: string;
     redisPort: number;
-    redisDataCache: {
+    memoizerRedis: {
         enabled: boolean,
+    },
+    uniswap: {
+        v3: {
+            networks: {
+                mainnet: string,
+                rinkeby: string,
+                goerli: string,
+                ropsten: string,
+                kovan: string,
+            }
+        }
     }
     port: string;
     requestLimit: string;

--- a/packages/server/src/util/date.ts
+++ b/packages/server/src/util/date.ts
@@ -1,1 +1,4 @@
-export const dayMs = 24 * 60 * 60 * 1000;
+export const secondMs = 1000;
+export const minuteMs = 60 * secondMs;
+export const hourMs = 60 * minuteMs;
+export const dayMs = 24 * hourMs;

--- a/packages/server/src/util/memoizer-redis/index.ts
+++ b/packages/server/src/util/memoizer-redis/index.ts
@@ -1,0 +1,125 @@
+import Redis from 'ioredis';
+import crypto from 'crypto';
+
+import { hourMs, secondMs } from 'util/date';
+import lockFactory from 'util/memoizer-redis/lock';
+
+// Not allowed to specify keyPrefix when memoizing a function
+interface MemoizerOptions {
+  lookupTimeout: number, // how long to wait on redis.get
+  ttl: number, // how long the value should be cached for in ms
+  hashArgs: (args: Array<any>) => string, // function to hash args
+};
+
+// Set keyPrefix when creating the memoizer factory
+interface MemoizerFactoryOptions extends MemoizerOptions {
+  keyPrefix: string, // namespace, recommend commit sha
+  lockTimeout: number, // how long to attempt to get a lock
+  lockRetry: number, // how long to wait before trying to aquire a lock again
+}
+
+export const defaultOptions: MemoizerFactoryOptions = {
+  lookupTimeout: secondMs * 4,
+  ttl: hourMs,
+  keyPrefix: '',
+  hashArgs: sha1,
+  lockTimeout: secondMs * 2,
+  lockRetry: 50,
+};
+
+export default function memoizerFactory(client: Redis.Redis, opts: Partial<MemoizerFactoryOptions> = {}) {
+  const prefix = opts.keyPrefix?.length ? `:${opts.keyPrefix}` : defaultOptions.keyPrefix;
+  const keyPrefix = `memo${prefix}`;
+  const memoizerFactoryOptions = {
+    ...defaultOptions,
+    ...opts,
+    keyPrefix,
+  };
+
+  const lock = lockFactory(client, memoizerFactoryOptions);
+
+  // memoizes a fn
+  return function memoizer<T>(fn: T, opts: Partial<MemoizerOptions> = {}) {
+    if (typeof fn !== 'function') {
+      throw new Error('Only functions can be memoized');
+    }
+    const fnKey = fn.name;
+    const {
+      lookupTimeout,
+      lockTimeout,
+      lockRetry,
+      keyPrefix,
+      ttl,
+      hashArgs
+    } = { ...memoizerFactoryOptions, ...opts };
+
+    // the actual memoized function
+    return async function memoized(...args: Array<any>): Promise<ReturnType<<T>() => T>> {
+      const cacheKey = getCacheKey(keyPrefix, fnKey, hashArgs(args));
+
+      // lookup in redis first
+      const firstLookup = await lookup(client, cacheKey, lookupTimeout);
+      if (firstLookup != null) {
+        // cache hit, return result
+        return firstLookup;
+      }
+
+      // couldn't find the value in redis, we may need to execute the fn ourselves and update redis
+      const unlock = await lock(cacheKey, lockTimeout, lockRetry);
+
+      // Check once more to see if it was written during another lock
+      let finalResult = await lookup(client, cacheKey, lookupTimeout);
+
+      // if our 2nd lookup was empty, we have to do work and update the cache
+      if (finalResult == null) {
+        // fine, we have to do the work now
+        finalResult = await fn(...args);
+        await writeKey(client, cacheKey, finalResult, ttl);
+      }
+
+      // dont wait for the unlock
+      unlock();
+
+      return finalResult;
+    }
+  }
+}
+
+export function sha1(args: Array<any>): string {
+  return crypto.createHash('sha1').update(JSON.stringify(args)).digest('hex');
+}
+
+export function getCacheKey(keyPrefix: string, fnKey: string, argsKey: string): string {
+  return `${keyPrefix}:${fnKey}:${argsKey}`;
+}
+
+export async function lookup(client: Redis.Redis, cacheKey: string, lookupTimeout: number): Promise<any | void> {
+  const getPromise = client.get(cacheKey);
+  const timeout = new Promise(resolve => setTimeout(resolve, lookupTimeout));
+
+  // try to fetch from redis until timeout is exceeded
+  const result = await Promise.race([getPromise, timeout]);
+  if (result != null) {
+    return deserialize(result);
+  }
+}
+
+export async function writeKey(client: Redis.Redis, cacheKey: string, data: any, ttl: number) {
+  const serialized = serialize(data);
+  await client.set(cacheKey, serialized, 'PX', ttl);
+}
+
+// TODO: Compress serialized data
+export function serialize(data: any): string {
+  return JSON.stringify(data);
+}
+export function deserialize(data: any): any {
+  try {
+    return JSON.parse(data);
+  } catch (error) {
+    const msg = 'Could not deserialize data from Redis.'
+    console.error(msg);
+
+    throw new Error(msg);
+  }
+}

--- a/packages/server/src/util/memoizer-redis/lock.ts
+++ b/packages/server/src/util/memoizer-redis/lock.ts
@@ -1,0 +1,54 @@
+import Redis from 'ioredis';
+
+interface LockOptions {
+  lockTimeout: number,
+  lockRetry: number,
+};
+
+type Locker = (lockKey: string, timeout: number, retry: number) => Promise<Unlocker>;
+type Unlocker = () => Promise<void>;
+
+const LOCK_SUCCESSFULY_SET = 'OK';
+
+// binds a redis client to the locking function
+export default function lockFactory(client: Redis.Redis, options: LockOptions): Locker {
+  const { lockTimeout, lockRetry } = options;
+
+  // locking fn
+  return async function lock(lockKey: string, timeout = lockTimeout, retry = lockRetry): Promise<Unlocker> {
+    lockKey = `lock:${lockKey}`;
+    const expireAt = Date.now() + timeout + 1;
+
+    // try to set a lock
+    await setLock(client, lockKey, expireAt, retry);
+      // caller can manually unlock before the lock expires
+    return async function unlock(): Promise<void> {
+      if (Date.now() < expireAt) {
+        await client.del(lockKey);
+      }
+    }
+  }
+}
+
+async function setLock(client: Redis.Redis, lockKey: string, expireAt: number, lockRetry: number): Promise<boolean> {
+  const lockTtl = expireAt - Date.now();
+  if (lockTtl <= 0) {
+    return false;
+  }
+
+  try {
+    // PX = key expiry in ms, NX = dont set if exists
+    const isSet = await client.set(lockKey, '1', 'PX', lockTtl, 'NX');
+
+    if (isSet !== LOCK_SUCCESSFULY_SET) {
+      throw new Error('Lock exists')
+    }
+
+    return true;
+  } catch (error) {
+    // Lock was not set for some reason. Could be network or an existing lock
+    // Try again after we waiting a bit
+    await new Promise(resolve => setTimeout(resolve, lockRetry));
+    return setLock(client, lockKey, expireAt, lockRetry);
+  }
+}

--- a/packages/server/test/api/controllers/pool.spec.ts
+++ b/packages/server/test/api/controllers/pool.spec.ts
@@ -2,10 +2,10 @@ import { endOfDay, endOfHour, subDays, subHours, startOfDay, startOfHour } from 
 import supertest from 'supertest';
 
 import { app } from 'common/server';
-import UV3Fetchers from 'services/uniswap-v3/fetchers';
+import { UniswapV3Fetchers } from 'services/uniswap-v3/fetchers';
 
 const request = supertest(app);
-const fetcher = UV3Fetchers.get('mainnet');
+const fetcher = UniswapV3Fetchers.get('mainnet');
 
 const validId = '0x1581d1a4f79885255e1993765ddee80c5e715181';
 


### PR DESCRIPTION
- All routes that currently support `/:network` in their paths will fetch against the appropriately configured subgraph url (config TBD)
  - V3 Fetcher manager creates a Fetcher for each network
  - Requests are namespaced to the network
  - networks are now validated in path
- Upgraded Redis caching logic
  - Minimize effect of cache stampedes by introducing locks when writing
  - Support namespaces
  - Can be disabled for testing