### PR TITLE
Chore/v3 gas buttons

### DIFF
--- a/packages/client/src/components/add-liquidity/add-liquidity-v3.tsx
+++ b/packages/client/src/components/add-liquidity/add-liquidity-v3.tsx
@@ -16,10 +16,10 @@ import { LiquidityContext } from 'containers/liquidity-container';
 import { TokenInput } from 'components/token-input';
 import { toastSuccess, toastWarn, toastError } from 'util/toasters';
 import { compactHash } from 'util/formats';
-// import { Grid } from 'react-loading-icons';
 import { WalletBalances } from 'types/states';
 import { useWallet } from 'hooks/use-wallet';
-import { useMarketData } from 'hooks/use-market-data';
+import { useMarketData } from 'hooks';
+import { EthGasPrices } from '@sommelier/shared-types';
 import { PoolOverview } from 'hooks/data-fetchers';
 import { debug } from 'util/debug';
 import classNames from 'classnames';
@@ -27,6 +27,7 @@ import classNames from 'classnames';
 type Props = {
     balances: WalletBalances;
     pool: PoolOverview | null;
+    gasPrices: EthGasPrices | null;
 };
 
 export type Sentiment = 'bullish' | 'bearish' | 'neutral';
@@ -36,6 +37,7 @@ const ETH_ID = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
 export const AddLiquidityV3 = ({
     pool,
     balances,
+    gasPrices,
 }: Props): JSX.Element | null => {
     const [priceImpact, setPriceImpact] = useState('0');
 
@@ -114,7 +116,13 @@ export const AddLiquidityV3 = ({
     const [tokenInputState, dispatch] = useReducer(reducer, initialState);
 
     // const [token, setToken] = useState('ETH');
-    const { currentGasPrice, slippageTolerance } = useContext(LiquidityContext);
+    // TODO calculate price impact
+    const { selectedGasPrice, slippageTolerance } = useContext(LiquidityContext);
+    let currentGasPrice: (number | null) = null;
+    if (gasPrices && selectedGasPrice) {
+        currentGasPrice = gasPrices[selectedGasPrice];
+    }
+
     const [sentiment, setSentiment] = useState<Sentiment>('neutral');
     const [bounds, setBounds] = useState<{
         prices: [number, number];
@@ -137,8 +145,8 @@ export const AddLiquidityV3 = ({
         pool?.token0,
         wallet.network
     );
-    (window as any).marketData = marketData;
-    (window as any).indicators = indicators;
+    debug.marketData = marketData;
+    debug.indicators = indicators;
 
     // returns a tuple [token0, token1];
     const getTokensWithAmounts = () => {

--- a/packages/client/src/containers/liquidity-container.tsx
+++ b/packages/client/src/containers/liquidity-container.tsx
@@ -1,5 +1,4 @@
-import {
-    useState,
+import { useState,
     useContext,
     useEffect,
     createContext,
@@ -19,23 +18,30 @@ import './liquidity-container.scss';
 import { ThreeDots } from 'react-loading-icons';
 import classNames from 'classnames';
 
+export enum GasPriceSelection {
+    Standard = 'standard',
+    Fast = 'fast',
+    Fastest = 'fastest',
+}
+
 type LiquidityContext = {
     poolId: string | null;
-    currentGasPrice: number | null;
+    selectedGasPrice: GasPriceSelection,
     slippageTolerance: number;
     setPoolId: Dispatch<SetStateAction<string | null>>;
-    setCurrentGasPrice: Dispatch<SetStateAction<number | null>>;
+    setSelectedGasPrice: Dispatch<SetStateAction<GasPriceSelection>>;
     setSlippageTolerance: Dispatch<SetStateAction<number>>;
 };
+
 const initialContext = {
     poolId: null,
-    selectedGasPrice: null,
+    selectedGasPrice: GasPriceSelection.Standard,
     slippageTolerance: 3.0,
-    currentGasPrice: null,
 };
 export const LiquidityContext = createContext<Partial<LiquidityContext>>(
     initialContext
 );
+
 const SearchHeader = ({
     setPoolId,
 }: {
@@ -51,20 +57,9 @@ const SearchHeader = ({
         >
             <div>{'Search Pairs'}</div>
             <PoolSearch setPoolId={setPoolId} />
-            {/* <div>
-                <button onClick={() => setPoolId(null)}>Clear</button>
-            </div> */}
         </Box>
     );
 };
-
-// const ActionBar = () => {
-//     return (
-//         <Box className='action-bar'>
-//             <button>Add Liquidity</button>
-//         </Box>
-//     );
-// };
 
 const TransactionSettings = ({
     gasPrices,
@@ -72,10 +67,11 @@ const TransactionSettings = ({
     gasPrices: EthGasPrices | null;
 }) => {
     // TODO why does TS think this could be undefined ?
-    const { currentGasPrice, setCurrentGasPrice } = useContext(
+    const { selectedGasPrice, setSelectedGasPrice } = useContext(
         LiquidityContext
     );
 
+<<<<<<< HEAD
     useEffect(() => {
         if (gasPrices && !currentGasPrice && setCurrentGasPrice) {
             setCurrentGasPrice(gasPrices.fast);
@@ -87,10 +83,15 @@ const TransactionSettings = ({
     const isSlowActive = currentGasPrice === gasPrices?.standard;
     const isNormalActive = currentGasPrice === gasPrices?.fast;
     const isFastActive = currentGasPrice === gasPrices?.fastest;
+=======
+    const isStandardActive = selectedGasPrice === GasPriceSelection.Standard;
+    const isNormalActive = selectedGasPrice === GasPriceSelection.Fast;
+    const isFastActive = selectedGasPrice === GasPriceSelection.Fastest;
+>>>>>>> 5651528 (fix eth price selection)
 
     return (
         <>
-            {gasPrices && setCurrentGasPrice && (
+            {setSelectedGasPrice && (
                 <Box
                     display='flex'
                     alignItems='center'
@@ -99,42 +100,35 @@ const TransactionSettings = ({
                     <div>Speed</div>
                     <div className='transaction-speed'>
                         <div
-                            className={classNames({ active: isSlowActive })}
+                            className={classNames({ active: isStandardActive })}
                             onClick={() =>
-                                setCurrentGasPrice(gasPrices?.standard)
+                                setSelectedGasPrice(GasPriceSelection.Standard)
                             }
                         >
-                            {isSlowActive && (
+                            {isStandardActive && (
                                 <FontAwesomeIcon icon={faCheckCircle} />
                             )}
-                            {gasPrices ? (
-                                <span>{`Slow ${gasPrices.standard} Gwei`}</span>
-                            ) : (
-                                <ThreeDots />
-                            )}
+                            <span>Standard {gasPrices?.standard ?? <ThreeDots height="17px" />} Gwei</span>
                         </div>
                         <div
                             className={classNames({ active: isNormalActive })}
-                            onClick={() => setCurrentGasPrice(gasPrices.fast)}
+                            onClick={() => setSelectedGasPrice(GasPriceSelection.Fast)}
                         >
                             {isNormalActive && (
                                 <FontAwesomeIcon icon={faCheckCircle} />
                             )}
-                            {!currentGasPrice && (
-                                <FontAwesomeIcon icon={faCheckCircle} />
-                            )}
-                            <span>{`Normal ${gasPrices.fast} Gwei`}</span>
+                            <span>Normal {gasPrices?.fast ?? <ThreeDots />} Gwei</span>
                         </div>
                         <div
                             className={classNames({ active: isFastActive })}
                             onClick={() =>
-                                setCurrentGasPrice(gasPrices.fastest)
+                                setSelectedGasPrice(GasPriceSelection.Fastest)
                             }
                         >
                             {isFastActive && (
                                 <FontAwesomeIcon icon={faCheckCircle} />
                             )}
-                            <span>{`Fast ${gasPrices.fastest} Gwei`}</span>
+                            <span>Fast {gasPrices?.fastest ?? <ThreeDots />} Gwei</span>
                         </div>
                     </div>
                     <div className='transaction-settings'>
@@ -153,10 +147,8 @@ export const LiquidityContainer = ({
 }): JSX.Element => {
     const [poolId, setPoolId] = useState<string | null>(null);
     const { data: pool } = usePoolOverview('rinkeby', poolId);
-    const [currentGasPrice, setCurrentGasPrice] = useState<number | null>(
-        gasPrices?.fast ?? null
-    );
     const [slippageTolerance, setSlippageTolerance] = useState(3.0);
+    const [selectedGasPrice, setSelectedGasPrice] = useState<GasPriceSelection>(GasPriceSelection.Fast);
     const balances = useBalance({
         pool,
     });
@@ -165,14 +157,13 @@ export const LiquidityContainer = ({
 
     return (
         <LiquidityContext.Provider
-            value={{ poolId, setPoolId, currentGasPrice, setCurrentGasPrice, slippageTolerance, setSlippageTolerance }}
+            value={{ poolId, setPoolId, selectedGasPrice, setSelectedGasPrice, slippageTolerance, setSlippageTolerance }}
         >
             <Box className='liquidity-container'>
                 <SearchHeader setPoolId={setPoolId} />
                 {poolId && pool && (
-                    <AddLiquidityV3 pool={pool} balances={balances} />
+                    <AddLiquidityV3 pool={pool} balances={balances} gasPrices={gasPrices} />
                 )}
-                {/* <ActionBar /> */}
                 {poolId && <TransactionSettings gasPrices={gasPrices} />}
             </Box>
         </LiquidityContext.Provider>

--- a/packages/client/src/containers/liquidity-container.tsx
+++ b/packages/client/src/containers/liquidity-container.tsx
@@ -71,23 +71,10 @@ const TransactionSettings = ({
         LiquidityContext
     );
 
-<<<<<<< HEAD
-    useEffect(() => {
-        if (gasPrices && !currentGasPrice && setCurrentGasPrice) {
-            setCurrentGasPrice(gasPrices.fast);
-        }
-    }, [gasPrices, setCurrentGasPrice]);
-
     // TODO show loader only for prices
-    if (!gasPrices) return <ThreeDots height='1rem' />;
-    const isSlowActive = currentGasPrice === gasPrices?.standard;
-    const isNormalActive = currentGasPrice === gasPrices?.fast;
-    const isFastActive = currentGasPrice === gasPrices?.fastest;
-=======
     const isStandardActive = selectedGasPrice === GasPriceSelection.Standard;
     const isNormalActive = selectedGasPrice === GasPriceSelection.Fast;
     const isFastActive = selectedGasPrice === GasPriceSelection.Fastest;
->>>>>>> 5651528 (fix eth price selection)
 
     return (
         <>
@@ -108,7 +95,7 @@ const TransactionSettings = ({
                             {isStandardActive && (
                                 <FontAwesomeIcon icon={faCheckCircle} />
                             )}
-                            <span>Standard {gasPrices?.standard ?? <ThreeDots height="17px" />} Gwei</span>
+                            <span>Standard {gasPrices?.standard ?? <ThreeDots width="24px" />} Gwei</span>
                         </div>
                         <div
                             className={classNames({ active: isNormalActive })}
@@ -117,7 +104,7 @@ const TransactionSettings = ({
                             {isNormalActive && (
                                 <FontAwesomeIcon icon={faCheckCircle} />
                             )}
-                            <span>Normal {gasPrices?.fast ?? <ThreeDots />} Gwei</span>
+                            <span>Normal {gasPrices?.fast ?? <ThreeDots width="24px"/>} Gwei</span>
                         </div>
                         <div
                             className={classNames({ active: isFastActive })}
@@ -128,7 +115,7 @@ const TransactionSettings = ({
                             {isFastActive && (
                                 <FontAwesomeIcon icon={faCheckCircle} />
                             )}
-                            <span>Fast {gasPrices?.fastest ?? <ThreeDots />} Gwei</span>
+                            <span>Fast {gasPrices?.fastest ?? <ThreeDots width="24px" />} Gwei</span>
                         </div>
                     </div>
                     <div className='transaction-settings'>

--- a/packages/client/src/hooks/index.ts
+++ b/packages/client/src/hooks/index.ts
@@ -1,1 +1,2 @@
-export * from './use-eth-price';
+export * from './use-eth-gas-prices';
+export * from './use-market-data';

--- a/packages/client/src/hooks/use-eth-gas-prices.ts
+++ b/packages/client/src/hooks/use-eth-gas-prices.ts
@@ -8,7 +8,7 @@ import config from 'config';
 export const ethGasPriceTopic = 'ethGas:getGasPrices';
 export const gasPriceTopicRex = /^ethGas:getGasPrices/;
 
-export function useEthGasPrices() {
+export function useEthGasPrices(): EthGasPrices | null {
     const [gasPrices, setGasPrices] = useState<EthGasPrices | null>(null);
 
     const [isSubscribed, setIsSubscribed] = useState<boolean>(false);
@@ -22,7 +22,7 @@ export function useEthGasPrices() {
             });
             setIsSubscribed(true);
         }
-    }, [isSubscribed]);
+    }, [isSubscribed, sendJsonMessage]);
 
     useEffect(() => {
         // if no message, bail
@@ -45,7 +45,7 @@ export function useEthGasPrices() {
 
             debug.gasPrices = newGasPrices;
         }
-    }, [lastJsonMessage]);
+    }, [lastJsonMessage, gasPrices]);
 
     return gasPrices;
 }


### PR DESCRIPTION
Fixes them gas buttons
- Gas button state does not get deselected when gas price changes
- Rename `Slow` -> `Standard`
- Move spinner to the gas price button

![image](https://user-images.githubusercontent.com/82778544/116963921-20a36700-ace5-11eb-8890-0dd1f6041821.png)
