### PR TITLE
feat/return gas price data on subscribe

### DIFF
--- a/packages/server/src/ws/message-handler.ts
+++ b/packages/server/src/ws/message-handler.ts
@@ -174,6 +174,13 @@ export default class WsMessageHandler {
 
         // We assume token is valid
         if (source === 'uniswap' || source === 'ethGas') {
+            // send latest data first
+            const latestData = pollingUtil.getLatestTopicData(topic);
+            if (latestData) {
+                this.sendJSON({ topic, data: latestData });
+            }
+
+            // subcribe to polling
             pollingUtil.subscribe(topic, interval).on('data', (data: unknown) =>
                 this.sendJSON({
                     topic,


### PR DESCRIPTION
- Cache latest data in a map on polling util
- return latest topic data immediately on subscribe

@kkennis i have this turned on for uniswap and gas price topics. let me know if it is a problem for the uniswap topic 