### PR TITLE
notify pending and confirmed tx, use pending context

### DIFF
--- a/packages/client/src/app.tsx
+++ b/packages/client/src/app.tsx
@@ -6,15 +6,12 @@ import { ErrorBoundary } from 'react-error-boundary';
 import {
     useState,
     useEffect,
-    ReactElement,
-    createContext,
-    Dispatch,
-    SetStateAction,
+    ReactElement
 } from 'react';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { useEthGasPrices } from 'hooks';
-
+import {PendingTxProvider} from 'hooks/use-pending-tx';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import LandingContainer from 'containers/landing-container';
@@ -23,24 +20,6 @@ import { PageError, ModalError } from 'components/page-error';
 
 import { WalletProvider } from 'hooks/use-wallet';
 
-export type PendingTx = {
-    approval: Array<string>;
-    confirm: Array<string>;
-};
-type PendingTxContext = {
-    pendingTx: PendingTx;
-    setPendingTx: Dispatch<SetStateAction<PendingTx>>;
-};
-
-const defaultPendingContext = {
-    pendingTx: {
-        approval: [],
-        confirm: [],
-    },
-};
-export const PendingTxContext = createContext<Partial<PendingTxContext>>(
-    defaultPendingContext
-);
 
 function App(): ReactElement {
     // ------------------ Initial Mount - API calls for first render ------------------
@@ -56,10 +35,7 @@ function App(): ReactElement {
     const [showConnectWallet, setShowConnectWallet] = useState(false);
 
     // subscribe to the hook, will propogate to the nearest boundary
-    const [pendingTx, setPendingTx] = useState<PendingTx>({
-        approval: [],
-        confirm: [],
-    });
+    
     const queryClient = new QueryClient();
     // useErrorHandler(error);
     useEffect(() => {
@@ -116,9 +92,7 @@ function App(): ReactElement {
                             className={classNames('app', 'dark')}
                             id='app-wrap'
                         >
-                            <PendingTxContext.Provider
-                                value={{ pendingTx, setPendingTx }}
-                            >
+                            <PendingTxProvider>
                                 <div className='app-body' id='app-body'>
                                     <>
                                         <ErrorBoundary
@@ -147,7 +121,7 @@ function App(): ReactElement {
                                         </ErrorBoundary>
                                     </>
                                 </div>
-                            </PendingTxContext.Provider>
+                            </PendingTxProvider>
                         </div>
                     </Router>
                 </QueryClientProvider>

--- a/packages/client/src/components/add-liquidity.tsx
+++ b/packages/client/src/components/add-liquidity.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import {
     Row,
     Col,
@@ -11,7 +11,7 @@ import { Box } from '@material-ui/core';
 
 import { ethers } from 'ethers';
 import BigNumber from 'bignumber.js';
-import { PendingTxContext, PendingTx } from 'app';
+import { usePendingTx, PendingTx } from 'hooks/use-pending-tx';
 import { compactHash } from 'util/formats';
 import { TokenInput } from 'components/token-input';
 import { WalletBalance } from 'components/wallet-balance';
@@ -97,7 +97,7 @@ function AddLiquidity({
     //     parseInt(balances[entryToken]?.decimals || '0', 10)
     // );
 
-    const { setPendingTx } = useContext(PendingTxContext);
+    const { setPendingTx } = usePendingTx();
 
     const resetForm = () => {
         setTokenOne('ETH');

--- a/packages/client/src/components/manage-liquidity-modal.tsx
+++ b/packages/client/src/components/manage-liquidity-modal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext } from 'react';
+import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { ButtonGroup, Modal } from 'react-bootstrap';
 import classNames from 'classnames';
@@ -14,7 +14,7 @@ import { UniswapApiFetcher as Uniswap } from 'services/api';
 import { usePairDataOverview } from 'hooks/use-pair-data-overview';
 import AddLiquidity from 'components/add-liquidity';
 import RemoveLiquidity from 'components/remove-liquidity';
-import { PendingTxContext, PendingTx } from 'app';
+import { usePendingTx, PendingTx } from 'hooks/use-pending-tx';
 import { useBalance } from 'hooks/use-balance-v2';
 import { debug } from 'util/debug';
 
@@ -41,7 +41,7 @@ function ManageLiquidityModal({
         positionData,
         setPositionData,
     ] = useState<LPPositionData<string> | null>(null);
-    const { setPendingTx } = useContext(PendingTxContext);
+    const { setPendingTx } = usePendingTx();
     let provider: ethers.providers.Web3Provider | null = null;
 
     if (wallet.provider) {

--- a/packages/client/src/components/pair-search.scss
+++ b/packages/client/src/components/pair-search.scss
@@ -23,12 +23,12 @@
     }
 }
 
-.MuiAutocomplete-root {
-    .Mui-focused {
-        // border: 1px solid var(--borderAccentAlt);
-        // border-radius: 2px;
-    }
-}
+// .MuiAutocomplete-root {
+//     .Mui-focused {
+//         // border: 1px solid var(--borderAccentAlt);
+//         // border-radius: 2px;
+//     }
+// }
 
 .MuiAutocomplete-endAdornment {
     color: var(--faceSecondary);

--- a/packages/client/src/components/pending-tx.tsx
+++ b/packages/client/src/components/pending-tx.tsx
@@ -1,11 +1,11 @@
-import { useContext, ReactElement } from 'react';
-import { PendingTxContext } from 'app';
+import { ReactElement } from 'react';
+import { usePendingTx } from 'hooks/use-pending-tx';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 
 // TODO Make a scroll UI component
 const PendingTx = (): ReactElement => {
-    const { pendingTx } = useContext(PendingTxContext);
+    const { pendingTx } = usePendingTx();
 
     const awaitingApproval = pendingTx?.approval.length ?? 0;
     const awaitingConfirm = pendingTx?.confirm.length ?? 0;

--- a/packages/client/src/components/pool-search.tsx
+++ b/packages/client/src/components/pool-search.tsx
@@ -116,6 +116,7 @@ export function PoolSearch({
 }
 
 function poolOptionLabel(pool: PoolLike): string {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return poolSymbol(pool, '/');
 }
 

--- a/packages/client/src/components/remove-liquidity.tsx
+++ b/packages/client/src/components/remove-liquidity.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useContext } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
     Container,
     Row,
@@ -14,7 +14,7 @@ import { Combobox } from 'react-widgets';
 import { ethers } from 'ethers';
 import BigNumber from 'bignumber.js';
 import { compactHash } from 'util/formats';
-import { PendingTxContext, PendingTx } from 'app';
+import { usePendingTx, PendingTx } from 'hooks/use-pending-tx';
 import mixpanel from 'util/mixpanel';
 import classNames from 'classnames';
 import erc20Abi from 'constants/abis/erc20.json';
@@ -67,7 +67,7 @@ function RemoveLiquidity({
         'needed'
     );
     const [txSubmitted, setTxSubmitted] = useState(false);
-    const { setPendingTx } = useContext(PendingTxContext);
+    const { setPendingTx } = usePendingTx();
     const resetForm = () => {
         setExitToken('ETH');
         setSlippageTolerance(3.0);

--- a/packages/client/src/containers/liquidity-container.tsx
+++ b/packages/client/src/containers/liquidity-container.tsx
@@ -1,6 +1,5 @@
 import { useState,
     useContext,
-    useEffect,
     createContext,
     Dispatch,
     SetStateAction,

--- a/packages/client/src/hooks/use-pending-tx.tsx
+++ b/packages/client/src/hooks/use-pending-tx.tsx
@@ -1,0 +1,49 @@
+import {
+    useState,
+    createContext,
+    useContext,
+    Dispatch,
+    SetStateAction,
+} from 'react';
+
+export type PendingTx = {
+    approval: Array<string>;
+    confirm: Array<string>;
+};
+
+type PendingTxContextType = {
+    pendingTx: PendingTx;
+    setPendingTx: Dispatch<SetStateAction<PendingTx>>;
+};
+
+const defaultPendingContext = {
+    pendingTx: {
+        approval: [],
+        confirm: [],
+    },
+};
+
+const PendingTxContext = createContext<Partial<PendingTxContextType>>(
+    defaultPendingContext
+);
+
+export const PendingTxProvider = ({
+    children,
+}: {
+    children: JSX.Element;
+}): JSX.Element => {
+    const [pendingTx, setPendingTx] = useState<PendingTx>({
+        approval: [],
+        confirm: [],
+    });
+
+    return (
+        <PendingTxContext.Provider value={{ pendingTx, setPendingTx }}>
+            {children}
+        </PendingTxContext.Provider>
+    );
+};
+
+export const usePendingTx = (): PendingTxContextType => {
+    return useContext(PendingTxContext) as PendingTxContextType;
+};


### PR DESCRIPTION
* Move pending tx context to a separate hook
* update pending tx widget on approvals and confirmations
* Notify approvals, confirmations and rejections