### PR TITLE
feat/sort pool dropdown by volumeUSD always

### DIFF
--- a/packages/client/src/components/pool-search.tsx
+++ b/packages/client/src/components/pool-search.tsx
@@ -10,6 +10,7 @@ import './pair-search.scss';
 import { resolveLogo } from 'components/token-with-logo';
 import { Box } from '@material-ui/core';
 import { poolSymbol, PoolLike } from 'util/formats';
+import BigNumber from 'bignumber.js';
 
 import { TopPool, useTopPools } from 'hooks/data-fetchers';
 import { ThreeDots } from 'react-loading-icons';
@@ -42,21 +43,10 @@ export function PoolSearch({
         return <ThreeDots height='1rem' />;
     }
 
-    // function sorter(a: UniswapPair, b: UniswapPair) {
-    //     const pairAReserve = parseInt(a?.volumeUSD);
-    //     const pairBReserve = parseInt(b?.volumeUSD);
-
-    //     if (pairAReserve > pairBReserve) return -1;
-
-    //     if (pairBReserve > pairAReserve) return 1;
-
-    //     return 0;
-    // }
-
     const poolFilter = (options: TopPool[], { inputValue }: any) =>
         matchSorter(options, inputValue, {
             keys: ['token0.symbol', 'token1.symbol', poolSymbol],
-        }).slice(0, 50);
+        }).sort(poolSortByVolume).slice(0, 50);
 
     const renderPoolWithLogo = (pool: TopPool) => (
         <div className='pair-option-with-logo'>
@@ -121,3 +111,13 @@ function poolOptionLabel(pool: PoolLike): string {
 }
 
 export default PoolSearch;
+
+// TODO: converting then sorting is about 15x slower than pre converting and sorting
+// We should re-evaluate converting some fields to big number right off the request
+// See the big-number-compare benchmark
+function poolSortByVolume(a: TopPool, b: TopPool) {
+    const volA = new BigNumber(a.volumeUSD);
+    const volB = new BigNumber(b.volumeUSD);
+
+    return volB.comparedTo(volA);
+}


### PR DESCRIPTION
- sort pools by volumeUSD in pool search dropdown
- add benchmark to see the effect of converting on the fly vs pre-converting

There is a pretty significant penalty for continually converting to big number while sorting. 1.3k vs 21k ops.  It doesn't matter if you've got 50 or 1000 items in the array either. 1.3k ops per a second doesnt really matter right now though so not a prio to refactor.