### PR TITLE
abort retries when handling coded errors in client + cache control on static

### DIFF
--- a/packages/server/src/api/middlewares/error.handler.ts
+++ b/packages/server/src/api/middlewares/error.handler.ts
@@ -6,7 +6,7 @@ import { CodedHTTPError, HTTPError, ValidationError } from 'api/util/errors';
 const internalError = 'Internal Server Error';
 
 // eslint-disable-next-line no-unused-vars, no-shadow
-export default function errorHandler(
+export function errorHandler(
     err: Error | HTTPError | CelebrateError,
     req: Request,
     res: Response,

--- a/packages/server/src/api/middlewares/index.ts
+++ b/packages/server/src/api/middlewares/index.ts
@@ -1,0 +1,2 @@
+export * from './error.handler';
+export * from './powered-by';

--- a/packages/server/src/api/middlewares/powered-by.ts
+++ b/packages/server/src/api/middlewares/powered-by.ts
@@ -1,0 +1,7 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function poweredByMiddleware(req: Request, res: Response, next: NextFunction) {
+    // override X-Powered-By: Express
+    res.set('X-Powered-By', 'Sommelier Finance');
+    next();
+}

--- a/packages/server/src/api/util/coded-http-errors.ts
+++ b/packages/server/src/api/util/coded-http-errors.ts
@@ -10,7 +10,7 @@ export class CodedHTTPError extends Error {
     public status: number;
     public code: number;
     public message: string;
-    public details: string | undefined;
+    public details: string;
 
     constructor(status: number, error: ICodedError | ErrorShape, details?: string) {
         super(error.message);
@@ -18,7 +18,7 @@ export class CodedHTTPError extends Error {
         this.status = status;
         this.code = error.code;
         this.message = error.message;
-        this.details = details;
+        this.details = details ?? '';
     }
 
     toString(): string {
@@ -29,7 +29,7 @@ export class CodedHTTPError extends Error {
         return {
             code: this.code,
             message: this.message,
-            details: this.details ?? '',
+            details: this.details,
         }
     }
 

--- a/packages/server/src/common/server.ts
+++ b/packages/server/src/common/server.ts
@@ -1,4 +1,4 @@
-import express, { Application } from 'express';
+import express, { Application, Request, Response, NextFunction } from 'express';
 import routes from 'routes';
 import path from 'path';
 import bodyParser from 'body-parser';
@@ -10,8 +10,8 @@ import swaggerUi from 'swagger-ui-express';
 import YAML from 'yamljs';
 import Mixpanel from 'mixpanel';
 
-import errorHandler from '../api/middlewares/error.handler';
 import * as OpenApiValidator from 'express-openapi-validator';
+import { errorHandler, poweredByMiddleware } from '../api/middlewares';
 
 import config from 'config';
 
@@ -30,26 +30,22 @@ class ExpressServer {
         const clientRoot = path.normalize(__dirname + '/../../../client');
         app.set('appPath', root + 'client');
 
+        // logging, should be first middleware
         app.use(morgan('dev'));
 
-        app.use(
-            bodyParser.json({ limit: config.requestLimit })
-        );
-        app.use(
-            bodyParser.urlencoded({
-                extended: true,
-                limit: config.requestLimit,
-            })
-        );
-        app.use(
-            bodyParser.text({ limit: config.requestLimit })
-        );
+        app.use(poweredByMiddleware);
         app.use(cookieParser(process.env.SESSION_SECRET));
-        app.use(express.static(`${root}/public`));
-        app.use(express.static(`${clientRoot}/build`));
+
+        app.use('/static/css', express.static(`${clientRoot}/build/static`, {
+            maxAge: '30d',
+            immutable: true,  // these files never change and can be cached for 1y
+        }));
+        app.use(express.static(`${clientRoot}/build`, {
+            maxAge: '1m', // index.html should be revalidated much more frequently
+        }));
 
         // Catch all
-        app.use(function (req, res, next) {
+        app.use(function (req: Request, res: Response, next: NextFunction) {
             if (req.url.includes('api')) return next();
 
             mixpanel?.track('server:page_load', { ip: req.ip });
@@ -59,11 +55,22 @@ class ExpressServer {
     }
 
     router(routes: (app: Application) => void): ExpressServer {
+        app.use(
+            bodyParser.urlencoded({
+                extended: true,
+                limit: config.requestLimit,
+            })
+        );
+        app.use(
+            bodyParser.text({ limit: config.requestLimit })
+        );
+
         routes(app);
         app.use(errorHandler);
         return this;
     }
 
+    // not being used for now
     mountExplorer(): void {
         const apiSpec = path.join(__dirname, '../docs/api.yml');
         let apiDoc;
@@ -75,7 +82,7 @@ class ExpressServer {
 
         if (apiDoc) {
             app.use('/api/explorer', swaggerUi.serve, swaggerUi.setup(apiDoc));
-            app.use(config.openApiSpec, express.static(apiSpec));
+            app.use(config.openApiSpec, express.static(apiSpec, { maxAge: '1h' }));
 
              const validateResponses = config.enableResponseValidation;
             app.use(

--- a/packages/server/src/common/server.ts
+++ b/packages/server/src/common/server.ts
@@ -36,7 +36,7 @@ class ExpressServer {
         app.use(poweredByMiddleware);
         app.use(cookieParser(process.env.SESSION_SECRET));
 
-        app.use('/static/css', express.static(`${clientRoot}/build/static`, {
+        app.use('/static', express.static(`${clientRoot}/build/static`, {
             maxAge: '30d',
             immutable: true,  // these files never change and can be cached for 1y
         }));

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -7,8 +7,6 @@ import config from 'config';
 function startServer() {
     const port = parseInt(config.port);
 
-    // TODO: figure out why YAML.load during mountExplorer breaks when running jest and start with tests
-    server.mountExplorer();
     server.listen(port);
 
     if (!server.httpServer) {

--- a/packages/server/src/services/bitquery/fetcher.ts
+++ b/packages/server/src/services/bitquery/fetcher.ts
@@ -93,12 +93,12 @@ export default class BitqueryFetcher {
         } catch (error) {
             // eslint-ignore-next-line
             console.error('Bitquery:', error.message);
-            throw UpstreamError;
+            throw UpstreamError.clone();
         }
 
         const dexTrades = result?.ethereum?.dexTrades;
         if (dexTrades == null || dexTrades.length === 0) {
-            throw UpstreamMissingPoolDataError;
+            throw UpstreamMissingPoolDataError.clone();
         }
 
         return dexTrades;

--- a/packages/sommelier-types/src/index.ts
+++ b/packages/sommelier-types/src/index.ts
@@ -153,9 +153,10 @@ export interface ICodedError {
     code: number;
     message: string;
     toString: () => string;
+    clone: () => CodedError;
 }
 
-class CodedError extends Error implements ICodedError {
+export class CodedError extends Error implements ICodedError {
     public code: number;
     public message: string;
 
@@ -168,6 +169,10 @@ class CodedError extends Error implements ICodedError {
 
     toString(): string {
         return `Error ${this.code}: ${this.message}`;
+    }
+
+    clone(): CodedError {
+        return new CodedError(this.code, this.message);
     }
 }
 


### PR DESCRIPTION
- don't retry when receiving a `UpstreamError` or `UpstreamMissingPoolDataError`
- retry once for all other errors on market data routes
![image](https://user-images.githubusercontent.com/82778544/117365757-bc59f080-aefa-11eb-9500-873078108bbe.png)
