### PR TITLE
Add editable liquidity ranges

### DIFF
--- a/packages/client/src/components/add-liquidity/add-liquidity-v3.scss
+++ b/packages/client/src/components/add-liquidity/add-liquidity-v3.scss
@@ -61,6 +61,9 @@
         justify-content: space-between;
         align-items: stretch;
     }
+    .liquidity-range-container {
+        margin-top: 1em;
+    }
     .preview {
         background: var(--bgDeep);
         font-size: 0.85rem;
@@ -72,6 +75,34 @@
         }
         .face-positive {
             color: var(--facePositive);
+        }
+    }
+    .liquidity-range {
+        text-align: center;
+
+        .liquidity-range-price-input {
+            font-size: 1.5em;
+            background: var(--bgDefault);
+            padding: 0.8rem 1rem;
+            border-radius: 4px;
+            border: 0;
+            color: var(--faceDeep);
+            &:hover,
+            &:focus,
+            &:active,
+            &:focus-visible {
+                border: 0;
+                box-shadow: none;
+                outline: none;
+            }
+            &.left {
+                text-align: right;
+            }
+            &::-webkit-outer-spin-button,
+            &::-webkit-inner-spin-button {
+                -webkit-appearance: none;
+                margin: 0;
+            }
         }
     }
     .btn-addl {

--- a/packages/client/src/components/add-liquidity/liquidity-range.tsx
+++ b/packages/client/src/components/add-liquidity/liquidity-range.tsx
@@ -1,0 +1,63 @@
+import { ThreeDots } from 'react-loading-icons';
+import { BoundsState } from 'types/states';
+
+interface Props {
+    pendingBounds: boolean;
+    isFlipped: boolean;
+    bounds: BoundsState;
+    updateRange: (value: number, index: 0 | 1) => void;
+}
+
+export const LiquidityRange = ({
+    pendingBounds,
+    isFlipped,
+    bounds,
+    updateRange,
+}: Props): JSX.Element => {
+    const leftPrice = isFlipped ? 1 / bounds.prices[1] : bounds.prices[0];
+    const rightPrice = isFlipped ? 1 / bounds.prices[0] : bounds.prices[1];
+    return (
+        <div className='liquidity-range-container'>
+            <p>Liquidity Range</p>
+            <div className='preview liquidity-range'>
+                {pendingBounds ? (
+                    <ThreeDots width='24px' height='10px' />
+                ) : (
+                    <>
+                        <input
+                            className='liquidity-range-price-input left'
+                            type='number'
+                            min='0'
+                            value={leftPrice}
+                            onChange={(e) => {
+                                const val = parseFloat(e.target.value);
+                                console.log('THIS IS VAL', val);
+                                if (isFlipped) {
+                                    updateRange(1 / val, 1);
+                                } else {
+                                    updateRange(val, 0);
+                                }
+                            }}
+                        />{' '}
+                        to{' '}
+                        <input
+                            className='liquidity-range-price-input'
+                            type='number'
+                            min='0'
+                            value={rightPrice}
+                            onChange={(e) => {
+                                const val = parseFloat(e.target.value);
+                                console.log('THIS IS VAL', val);
+                                if (isFlipped) {
+                                    updateRange(1 / val, 0);
+                                } else {
+                                    updateRange(val, 1);
+                                }
+                            }}
+                        />
+                    </>
+                )}
+            </div>
+        </div>
+    );
+};


### PR DESCRIPTION
Screenshot: 

![Screen Shot 2021-06-07 at 6 10 07 PM](https://user-images.githubusercontent.com/12480403/121106805-99ea1a00-c7bb-11eb-9df0-b77c3d1ae6ac.png)

This emulates Josh's mockup in the design channel but with the look/feel we currently have. 

Needed to change some state handling to be less coupled to the `indicators` primitive, and have it work with bounds more, since editable ranges give us bounds outside the context of an indicator. I also moved `LiquidityBounds` into a separate file.
