### PR TITLE
Chore/share pool link

### DIFF
--- a/packages/client/src/components/add-liquidity/add-liquidity-v3.scss
+++ b/packages/client/src/components/add-liquidity/add-liquidity-v3.scss
@@ -63,6 +63,9 @@
     }
     .liquidity-range-container {
         margin-top: 1em;
+        display: flex;
+        flex-grow: 1;
+        justify-content: space-between;
     }
     .preview {
         background: var(--bgDeep);
@@ -79,8 +82,8 @@
     }
     .liquidity-range {
         font-size: 0.85rem;
-        background: var(--bgDefault);
-        padding: 0.75rem;
+        // background: var(--bgDefault);
+        // padding: 0.75rem;
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -88,15 +91,15 @@
         .liquidity-range-price-input {
             font-size: 1rem;
             background: var(--bgDeep);
-            padding: 0.8rem 1rem;
+            padding: 0.25rem;
             border-radius: 4px;
-            border: 0;
+            border: 1px solid var(--objDefaultAlt);
             color: var(--faceDeep);
             &:hover,
             &:focus,
             &:active,
             &:focus-visible {
-                border: 0;
+                border: 1px solid var(--objPrimaryAlt);
                 box-shadow: none;
                 outline: none;
             }

--- a/packages/client/src/components/add-liquidity/add-liquidity-v3.scss
+++ b/packages/client/src/components/add-liquidity/add-liquidity-v3.scss
@@ -78,11 +78,16 @@
         }
     }
     .liquidity-range {
-        text-align: center;
+        font-size: 0.85rem;
+        background: var(--bgDefault);
+        padding: 0.75rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
 
         .liquidity-range-price-input {
-            font-size: 1.5em;
-            background: var(--bgDefault);
+            font-size: 1rem;
+            background: var(--bgDeep);
             padding: 0.8rem 1rem;
             border-radius: 4px;
             border: 0;
@@ -196,8 +201,12 @@
         text-align: center;
     }
 
-    .sentiment-button + .sentiment-button {
-        // margin-left: 1em;
+    .shorts-button {
+        cursor: pointer;
+        padding: 5px 10px;
+        background: var(--objDefault);
+        border: 1px solid var(--borderPrimary);
+        color: var(--faceDefault);
     }
 
     .token-select {

--- a/packages/client/src/components/add-liquidity/add-liquidity-v3.scss
+++ b/packages/client/src/components/add-liquidity/add-liquidity-v3.scss
@@ -386,11 +386,13 @@
         > div {
             display: flex;
             flex-direction: column;
-            border: 1px solid red;
         }
     }
     .add-v3-container {
         .sentiment {
+            flex-direction: column;
+        }
+        .liquidity-range {
             flex-direction: column;
         }
     }

--- a/packages/client/src/components/add-liquidity/add-liquidity-v3.tsx
+++ b/packages/client/src/components/add-liquidity/add-liquidity-v3.tsx
@@ -1760,12 +1760,6 @@ export const AddLiquidityV3 = ({
                         />
                     </Box>
                 </Box>
-                <LiquidityRange
-                    pendingBounds={pendingBounds}
-                    isFlipped={isFlipped}
-                    bounds={bounds}
-                    updateRange={updateRange}
-                />
                 <br />
                 <p>Market Sentiment</p>
                 <Box
@@ -1845,22 +1839,17 @@ export const AddLiquidityV3 = ({
                             </span>
                         </div>
                     </Box>
-                    <Box display='flex' justifyContent='space-between'>
-                        <div>Liquidity Range</div>
-                        <div>
-                            <span className='face-positive'>
-                                {pendingBounds ? (
-                                    <ThreeDots width='24px' height='10px' />
-                                ) : isFlipped ? (
-                                    `${1 / bounds.prices[1]} to ${
-                                        1 / bounds.prices[0]
-                                    }`
-                                ) : (
-                                    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-                                    `${bounds.prices[0]} to ${bounds.prices[1]}`
-                                )}
-                            </span>
-                        </div>
+                    <Box
+                        display='flex'
+                        justifyContent='space-between'
+                        flexDirection='column'
+                    >
+                        <LiquidityRange
+                            pendingBounds={pendingBounds}
+                            isFlipped={isFlipped}
+                            bounds={bounds}
+                            updateRange={updateRange}
+                        />
                     </Box>
                     {/* TODO Re-introduce once we know per-tick liquidity
                         {selectedSymbolCount == 1 && (

--- a/packages/client/src/components/add-liquidity/add-liquidity-v3.tsx
+++ b/packages/client/src/components/add-liquidity/add-liquidity-v3.tsx
@@ -53,6 +53,7 @@ import classNames from 'classnames';
 type Props = {
     balances: WalletBalances;
     pool: PoolOverview | null;
+    shortUrl: string | null;
     gasPrices: EthGasPrices | null;
 };
 
@@ -63,6 +64,7 @@ const ETH_ID = config.ethAddress;
 export const AddLiquidityV3 = ({
     pool,
     balances,
+    shortUrl,
     gasPrices,
 }: Props): JSX.Element | null => {
     const [priceImpact, setPriceImpact] = useState('0');
@@ -1444,7 +1446,29 @@ export const AddLiquidityV3 = ({
     return (
         <>
             <div className='add-v3-container'>
-                <p>Select 1 or 2 token(s)</p>
+                <Box
+                    display='flex'
+                    flexDirection='row'
+                    justifyContent='space-between'
+                    marginBottom='8px'
+                    alignItems='center'
+                >
+                    <div>Select 1 or 2 token(s)</div>
+                    <div
+                        style={{
+                            cursor: 'pointer',
+                            padding: '5px 10px',
+                            background: 'var(--objDefault)',
+                            border: '1px solid var(--borderPrimary)',
+                            color: 'var(--faceDefault)',
+                        }}
+                        onClick={() => {
+                            void navigator.clipboard.writeText(shortUrl || '');
+                        }}
+                    >
+                        {`Copy ${token0Symbol}/${token1Symbol} Link`}
+                    </div>
+                </Box>
                 <Box
                     display='flex'
                     flexDirection='column'

--- a/packages/client/src/components/add-liquidity/add-liquidity-v3.tsx
+++ b/packages/client/src/components/add-liquidity/add-liquidity-v3.tsx
@@ -81,6 +81,7 @@ export const AddLiquidityV3 = ({
     }>({ status: false, message: <p>Warning placeholder</p> });
     const [isFlipped, setIsFlipped] = useState<boolean>(false);
     // State here is used to compute what tokens are being used to add liquidity with.
+    const [copiedShortUrl, setCopiedShortUrl] = useState<boolean>(false);
     const initialState: Record<string, any> = useMemo(
         () => ({
             [token0Symbol]: {
@@ -1455,18 +1456,14 @@ export const AddLiquidityV3 = ({
                 >
                     <div>Select 1 or 2 token(s)</div>
                     <div
-                        style={{
-                            cursor: 'pointer',
-                            padding: '5px 10px',
-                            background: 'var(--objDefault)',
-                            border: '1px solid var(--borderPrimary)',
-                            color: 'var(--faceDefault)',
-                        }}
+                        className='shorts-button'
                         onClick={() => {
                             void navigator.clipboard.writeText(shortUrl || '');
+                            setCopiedShortUrl(true);
                         }}
                     >
-                        {`Copy ${token0Symbol}/${token1Symbol} Link`}
+                        {copiedShortUrl ? 'Copied' : 'Copy'}
+                        {` ${token0Symbol}/${token1Symbol} Link`}
                     </div>
                 </Box>
                 <Box

--- a/packages/client/src/components/add-liquidity/liquidity-range.tsx
+++ b/packages/client/src/components/add-liquidity/liquidity-range.tsx
@@ -19,42 +19,48 @@ export const LiquidityRange = ({
     return (
         <div className='liquidity-range-container'>
             <p>Liquidity Range</p>
-            <div className='preview liquidity-range'>
+            <div className='liquidity-range'>
                 {pendingBounds ? (
                     <ThreeDots width='24px' height='10px' />
                 ) : (
                     <>
-                        <input
-                            className='liquidity-range-price-input left'
-                            type='number'
-                            min='0'
-                            value={leftPrice}
-                            onChange={(e) => {
-                                const val = parseFloat(e.target.value);
-                                console.log('THIS IS VAL', val);
-                                if (isFlipped) {
-                                    updateRange(1 / val, 1);
-                                } else {
-                                    updateRange(val, 0);
-                                }
-                            }}
-                        />{' '}
-                        to{' '}
-                        <input
-                            className='liquidity-range-price-input'
-                            type='number'
-                            min='0'
-                            value={rightPrice}
-                            onChange={(e) => {
-                                const val = parseFloat(e.target.value);
-                                console.log('THIS IS VAL', val);
-                                if (isFlipped) {
-                                    updateRange(1 / val, 0);
-                                } else {
-                                    updateRange(val, 1);
-                                }
-                            }}
-                        />
+                        <div>
+                            <input
+                                className='liquidity-range-price-input left'
+                                type='number'
+                                min='0'
+                                value={leftPrice}
+                                onChange={(e) => {
+                                    const val = parseFloat(e.target.value);
+                                    console.log('THIS IS VAL', val);
+                                    if (isFlipped) {
+                                        updateRange(1 / val, 1);
+                                    } else {
+                                        updateRange(val, 0);
+                                    }
+                                }}
+                            />
+                            &nbsp;
+                        </div>
+                        <div>to</div>
+                        <div>
+                            {' '}
+                            <input
+                                className='liquidity-range-price-input'
+                                type='number'
+                                min='0'
+                                value={rightPrice}
+                                onChange={(e) => {
+                                    const val = parseFloat(e.target.value);
+                                    console.log('THIS IS VAL', val);
+                                    if (isFlipped) {
+                                        updateRange(1 / val, 0);
+                                    } else {
+                                        updateRange(val, 1);
+                                    }
+                                }}
+                            />
+                        </div>
                     </>
                 )}
             </div>

--- a/packages/client/src/components/add-liquidity/liquidity-range.tsx
+++ b/packages/client/src/components/add-liquidity/liquidity-range.tsx
@@ -18,7 +18,7 @@ export const LiquidityRange = ({
     const rightPrice = isFlipped ? 1 / bounds.prices[0] : bounds.prices[1];
     return (
         <div className='liquidity-range-container'>
-            <p>Liquidity Range</p>
+            <div>Liquidity Range</div>
             <div className='liquidity-range'>
                 {pendingBounds ? (
                     <ThreeDots width='24px' height='10px' />
@@ -44,7 +44,7 @@ export const LiquidityRange = ({
                         </div>
                         <div>to</div>
                         <div>
-                            {' '}
+                            &nbsp;
                             <input
                                 className='liquidity-range-price-input'
                                 type='number'

--- a/packages/client/src/containers/liquidity-container.tsx
+++ b/packages/client/src/containers/liquidity-container.tsx
@@ -1,5 +1,6 @@
 import {
     useState,
+    useEffect,
     useContext,
     createContext,
     Dispatch,
@@ -157,12 +158,24 @@ export const LiquidityContainer = ({
     gasPrices: EthGasPrices | null;
 }): JSX.Element => {
     const { poolId }: { poolId: string } = useParams();
-
+    const [shortUrl, setShortUrl] = useState(null);
     const { wallet } = useWallet();
     const { data: pool, isLoading, isError } = usePoolOverview(
         wallet.network,
         poolId,
     );
+
+    useEffect(() => {
+        if (!poolId) return;
+        const getShortUrl = async () => {
+            const data = await (
+                await fetch(`/api/v1/mainnet/pools/${poolId}/shorts`)
+            ).json();
+            setShortUrl(data);
+        };
+
+        void getShortUrl();
+    }, [poolId]);
 
     const [slippageTolerance, setSlippageTolerance] = useState(3.0);
     const [selectedGasPrice, setSelectedGasPrice] = useState<GasPriceSelection>(
@@ -193,6 +206,7 @@ export const LiquidityContainer = ({
                 {poolId && pool && (
                     <AddLiquidityV3
                         pool={pool}
+                        shortUrl={shortUrl}
                         balances={balances}
                         gasPrices={gasPrices}
                     />

--- a/packages/client/src/styles/themes.scss
+++ b/packages/client/src/styles/themes.scss
@@ -8,9 +8,13 @@
     --bgSecondary: var(--purple70);
 
     --objDeep: var(--purple90);
+    --objDeepAlt: var(--purple80);
     --objDefault: var(--purple80);
+    --objDefaultAlt: var(--purple70);
     --objPrimary: var(--purple70);
+    --objPrimaryAlt: var(--purple60);
     --objSecondary: var(--purple60);
+    --objSecondaryAlt: var(--purple50);
     --objPositive: var(--green70);
     --objPositiveAlt: var(--green60);
     --objNegative: var(--red70);


### PR DESCRIPTION
The last commit on this PR updates how the liquidity range is rendered, can revert if the team doesnot agree with my proposal. Got the 👍 on this from Josh btw.

While trying out the liquidity range editor i found 
* i needed to use the flip to get meaningful number ranges. 
* as a non trader user, seeing this big editable range i start to think if there is some action i needed to take with the range, lower my confidence in wanting to add liquidity 
* my proposal gives the user the feature to edit the ranges but nice conceals it right next to token flip and only reveals itself if the user knows what they are doing and wants to use this feature.

<img width="550" alt="Screen Shot 2021-06-08 at 2 08 43 AM" src="https://user-images.githubusercontent.com/6791048/121157512-7b594280-c7fe-11eb-8900-3e008ebaef73.png">
