### PR TITLE
configurable core multiplier

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,4 +1,6 @@
-const numCores = require('os').cpus().length;
+const numCores = require("os").cpus().length;
+let coreMultiplier = process.env["APP_CORE_MULTIPLIER"];
+coreMultiplier = coreMultiplier?.length > 0 ? parseInt(coreMultiplier, 10) : 1;
 
 module.exports = {
   apps: [
@@ -6,8 +8,8 @@ module.exports = {
       name: "app-server",
       script: "packages/server/dist/www.js",
       cwd: "/app/il-loss-charts",
-      exec_mode: 'cluster',
-      instances: Math.floor(numCores * 1.5), // should be able to run more instances than cores due to interleaving
+      exec_mode: "cluster",
+      instances: Math.floor(numCores * coreMultiplier),
       combine_logs: true,
       out_file: process.env.APP_LOG || "./out.log",
       error_file: process.env.APP_ERR_LOG || "./err.log",


### PR DESCRIPTION
Plan is to scale down from e2-standard to e2-medium which uses shared cores. This should be 99.9% the same as using the standard instance. There may be a handful of requests that are a tad slower but Google estimates this to be 1 in 1000. Read a little more about the e2 instance scheduling here: https://cloud.google.com/blog/products/compute/understanding-dynamic-resource-management-in-e2-vms.

This means we should run 1:1 mapping of processes to vCPUs for this instance time so i've scaled the core multiplier from 1.5 to 1.