### PR TITLE
consistent info layout for position summary and price range

### DIFF
--- a/packages/client/src/components/positions/positions-detail.tsx
+++ b/packages/client/src/components/positions/positions-detail.tsx
@@ -84,7 +84,6 @@ export const PositionsDetail = ({
                         sx={{
                             border: '1px solid var(--borderDefault)',
                             padding: '0.5rem',
-                            bgcolor: 'var(--objPrimary)',
                             borderRadius: '4px',
                             fontSize: '0.75rem',
                         }}
@@ -101,9 +100,9 @@ export const PositionsDetail = ({
                     {position?.pool?.token0?.symbol}/
                     {position?.pool?.token1?.symbol}
                     &nbsp;
-                    <RangeStatus position={position} />
                 </div>
-                <Box
+                <RangeStatus position={position} />
+                {/* <Box
                     sx={{
                         border: '1px solid var(--borderPrimary)',
                         padding: '0.5rem',
@@ -120,39 +119,33 @@ export const PositionsDetail = ({
                     &nbsp;
                     {copiedShortUrl ? 'Copied' : 'Copy'}
                     {' Pool Link'}
-                </Box>
+                </Box> */}
             </Box>
             <Box
                 display='flex'
+                width='100%'
+                flexWrap='wrap'
+                justifyContent='space-between'
+                mb='1rem'
                 sx={{
-                    fontSize: '1rem',
-                    bgcolor: 'var(--bgDeep)',
-                    padding: '1rem',
+                    border: '1px solid var(--borderDefault)',
                     borderRadius: '4px',
-                    lineHeight: '1.75rem',
-                    mb: '1rem',
+                    padding: '1rem',
                 }}
             >
-                <Box
-                    display='flex'
-                    flexDirection='column'
-                    flexGrow='1'
-                    justifyContent='center'
-                    sx={{ fontSize: '0.75rem' }}
-                >
-                    <div>Entry Liquidity</div>
-                    <div>Current Size</div>
-                    <div>Earned Fees</div>
-                    <div>APY</div>
+                <Box flexGrow='1'>
+                    <Box lineHeight='2rem' color='var(--faceDeep)'>
+                        {formatUSD(stats?.entryUsdAmount?.toString())}
+                    </Box>
+                    <Box fontSize='0.75rem'>Entry Liquidity</Box>
                 </Box>
-                <Box
-                    display='flex'
-                    flexDirection='column'
-                    flexGrow='1'
-                    alignItems='flex-end'
-                >
-                    <div>{formatUSD(stats?.entryUsdAmount?.toString())}</div>
-                    <div>{formatUSD(stats?.usdAmount?.toString())}</div>
+                <Box flexGrow='1'>
+                    <Box lineHeight='2rem' color='var(--faceDeep)'>
+                        {formatUSD(stats?.usdAmount?.toString())}
+                    </Box>
+                    <Box fontSize='0.75rem'>Current Size</Box>
+                </Box>
+                <Box flexGrow='1'>
                     <div>
                         <FormatPNL
                             isNegative={new BigNumber(
@@ -162,6 +155,9 @@ export const PositionsDetail = ({
                             {formatUSD(stats?.totalFeesUSD?.toString())}
                         </FormatPNL>
                     </div>
+                    <Box fontSize='0.75rem'>Earned Fees</Box>
+                </Box>
+                <Box flexGrow='1'>
                     <div>
                         <FormatPNL
                             isNegative={new BigNumber(stats?.apy).isNegative()}
@@ -169,6 +165,7 @@ export const PositionsDetail = ({
                             {formatPercent(stats?.apy?.toString())}
                         </FormatPNL>
                     </div>
+                    <Box fontSize='0.75rem'>APY</Box>
                 </Box>
             </Box>
             {showRemoveLiquidity ? (
@@ -180,59 +177,49 @@ export const PositionsDetail = ({
             ) : (
                 <>
                     <Box mb='1rem'>
-                        <Box mb='1rem'>Liquidity Range</Box>
                         <Box
                             display='flex'
+                            justifyContent='space-between'
+                            mb='1rem'
+                            alignItems='center'
+                        >
+                            <Box>Liquidity Range</Box>
+                            <Box
+                                sx={{
+                                    border: '1px solid var(--borderDefault)',
+                                    padding: '0.5rem',
+                                    borderRadius: '4px',
+                                    fontSize: '0.75rem',
+                                }}
+                                onClick={() => {
+                                    void navigator.clipboard.writeText(
+                                        shortUrl || '',
+                                    );
+                                    setCopiedShortUrl(true);
+                                }}
+                                style={{ cursor: 'pointer' }}
+                            >
+                                <FontAwesomeIcon icon={faCopy} />
+                                &nbsp;
+                                {copiedShortUrl ? 'Copied' : 'Copy'}
+                                {' Pool Link'}
+                            </Box>
+                        </Box>
+                        <Box
                             sx={{
-                                border: '1px solid var(--borderPrimary)',
+                                border: '1px solid var(--borderDefault)',
                                 borderRadius: '4px',
                                 textAlign: 'center',
+                                bgcolor: 'var(--bgDeep)',
                             }}
                         >
                             <Box
                                 sx={{
                                     flexGrow: '1',
-                                    padding: '1rem',
-                                    borderRight:
-                                        '1px solid var(--borderPrimary)',
-                                    maxWidth: '33%',
-                                    overflow: 'hidden',
-                                    whiteSpace: 'nowrap',
-                                    textOverflow: 'ellipsis',
-                                }}
-                            >
-                                <Box fontSize='0.75rem'>Lower Bound</Box>
-                                <Box
-                                    sx={{
-                                        color: 'var(--faceDeep)',
-                                        overflow: 'hidden',
-                                        whiteSpace: 'nowrap',
-                                        textOverflow: 'ellipsis',
-                                    }}
-                                >
-                                    {isFlipped
-                                        ? parseFloat(
-                                              position?.tickLower?.price0,
-                                          )
-                                        : parseFloat(
-                                              position?.tickUpper?.price1,
-                                          )}
-                                </Box>
-                                <Box>
-                                    <span style={{ fontSize: '0.75rem' }}>
-                                        {isFlipped
-                                            ? `${pool?.token1?.symbol} per ${pool?.token0?.symbol}`
-                                            : `${pool?.token0?.symbol} per ${pool?.token1?.symbol}`}
-                                    </span>
-                                </Box>
-                            </Box>
-                            <Box
-                                sx={{
-                                    flexGrow: '1',
-                                    padding: '1rem',
-                                    borderRight:
-                                        '1px solid var(--borderPrimary)',
-                                    maxWidth: '33%',
+                                    padding: '0.5rem 1rem',
+                                    display: 'flex',
+                                    justifyContent: 'space-between',
+                                    alignItems: 'center',
                                 }}
                             >
                                 <Box fontSize='0.75rem'>Current Price</Box>
@@ -247,13 +234,9 @@ export const PositionsDetail = ({
                                     {isFlipped
                                         ? 1 / parseFloat(pool?.token0Price)
                                         : parseFloat(pool?.token0Price)}
-                                </Box>
-                                <Box>
+                                    &nbsp;
                                     <span
                                         style={{
-                                            background: 'var(--objPrimary)',
-                                            padding: '0.25rem 0.5rem',
-                                            borderRadius: '4px',
                                             fontSize: '0.85rem',
                                         }}
                                     >
@@ -284,11 +267,68 @@ export const PositionsDetail = ({
                             <Box
                                 sx={{
                                     flexGrow: '1',
-                                    padding: '1rem',
-                                    maxWidth: '33%',
+                                    padding: '0.5rem 1rem',
                                     overflow: 'hidden',
                                     whiteSpace: 'nowrap',
                                     textOverflow: 'ellipsis',
+                                    display: 'flex',
+                                    justifyContent: 'space-between',
+                                }}
+                            >
+                                <Box fontSize='0.75rem'>Lower Bound</Box>
+                                <Box
+                                    sx={{
+                                        color: 'var(--faceDeep)',
+                                        overflow: 'hidden',
+                                        whiteSpace: 'nowrap',
+                                        textOverflow: 'ellipsis',
+                                    }}
+                                >
+                                    {isFlipped
+                                        ? parseFloat(
+                                              position?.tickLower?.price0,
+                                          )
+                                        : parseFloat(
+                                              position?.tickUpper?.price1,
+                                          )}
+                                    <span
+                                        style={{
+                                            fontSize: '0.85rem',
+                                        }}
+                                    >
+                                        {' '}
+                                        {isFlipped
+                                            ? pool.token1.symbol
+                                            : pool.token0.symbol}
+                                        <span
+                                            onClick={() =>
+                                                setIsFlipped(!isFlipped)
+                                            }
+                                            style={{
+                                                cursor: 'pointer',
+                                                color: 'var(--objHighlight)',
+                                                padding: '0.5rem',
+                                            }}
+                                        >
+                                            <FontAwesomeIcon
+                                                icon={faExchangeAlt}
+                                            />
+                                        </span>
+                                        {isFlipped
+                                            ? pool.token0.symbol
+                                            : pool.token1.symbol}
+                                    </span>
+                                </Box>
+                            </Box>
+                            <Box
+                                sx={{
+                                    flexGrow: '1',
+                                    padding: '0.5rem 1rem',
+                                    overflow: 'hidden',
+                                    whiteSpace: 'nowrap',
+                                    textOverflow: 'ellipsis',
+                                    display: 'flex',
+                                    justifyContent: 'space-between',
                                 }}
                             >
                                 <Box fontSize='0.75rem'>Upper Bound</Box>
@@ -307,12 +347,33 @@ export const PositionsDetail = ({
                                         : parseFloat(
                                               position?.tickLower?.price1,
                                           )}
-                                </Box>
-                                <Box>
-                                    <span style={{ fontSize: '0.75rem' }}>
+                                    &nbsp;
+                                    <span
+                                        style={{
+                                            fontSize: '0.85rem',
+                                        }}
+                                    >
+                                        {' '}
                                         {isFlipped
-                                            ? `${pool?.token1?.symbol} per ${pool?.token0?.symbol}`
-                                            : `${pool?.token0?.symbol} per ${pool?.token1?.symbol}`}
+                                            ? pool.token1.symbol
+                                            : pool.token0.symbol}
+                                        <span
+                                            onClick={() =>
+                                                setIsFlipped(!isFlipped)
+                                            }
+                                            style={{
+                                                cursor: 'pointer',
+                                                color: 'var(--objHighlight)',
+                                                padding: '0.5rem',
+                                            }}
+                                        >
+                                            <FontAwesomeIcon
+                                                icon={faExchangeAlt}
+                                            />
+                                        </span>
+                                        {isFlipped
+                                            ? pool.token0.symbol
+                                            : pool.token1.symbol}
                                     </span>
                                 </Box>
                             </Box>

--- a/packages/client/src/components/positions/positions-summary.tsx
+++ b/packages/client/src/components/positions/positions-summary.tsx
@@ -45,7 +45,7 @@ export const PositionsSummary = ({
                 </Box>
             </Box>
             <Box bgcolor='var(--bgDefault)' borderRadius='4px'>
-                <Box display='flex'>
+                <Box display='flex' flexWrap='wrap'>
                     <Box sx={overviewItemStyles}>
                         <div
                             style={{

--- a/packages/client/src/components/positions/positions.scss
+++ b/packages/client/src/components/positions/positions.scss
@@ -70,14 +70,14 @@ button.remove-position {
 }
 
 button.cancel-remove {
-    background: var(--objDefault);
     padding: 1rem;
-    border: 1px solid var(--objDefaultAlt);
+    background: var(--objDeep);
+    border: 1px solid var(--borderDefault);
     border-radius: 4px;
     cursor: pointer;
     color: var(--faceDefault);
     width: 50%;
     &:hover {
-        background: var(--objDefaultAlt);
+      background: var(--objDefault);
     }
 }

--- a/packages/client/src/components/positions/positions.scss
+++ b/packages/client/src/components/positions/positions.scss
@@ -52,6 +52,32 @@
     }
 }
 
-.MuiSlider-root.MuiSlider-colorPrimary{
+.MuiSlider-root.MuiSlider-colorPrimary {
     color: var(--objPrimary);
+}
+
+button.remove-position {
+    background: var(--objAccent);
+    padding: 1rem;
+    border: 1px solid var(--objAccentAlt);
+    border-radius: 4px;
+    cursor: pointer;
+    color: var(--faceDefault);
+    width: 50%;
+    &:hover {
+        background: var(--objAccentAlt);
+    }
+}
+
+button.cancel-remove {
+    background: var(--objDefault);
+    padding: 1rem;
+    border: 1px solid var(--objDefaultAlt);
+    border-radius: 4px;
+    cursor: pointer;
+    color: var(--faceDefault);
+    width: 50%;
+    &:hover {
+        background: var(--objDefaultAlt);
+    }
 }

--- a/packages/client/src/components/positions/remove-position.tsx
+++ b/packages/client/src/components/positions/remove-position.tsx
@@ -328,10 +328,11 @@ export const RemovePosition = ({
                 display='flex'
                 justifyContent='space-between'
                 borderRadius='4px'
+                border='1px solid var(--borderDefault)'
                 bgcolor='var(--bgDeep)'
                 mb='1rem'
-                p='1rem'
-                lineHeight='1.75rem'
+                p='0.5rem'
+                // lineHeight='1.75rem'
             >
                 <table width='100%'>
                     <thead>
@@ -341,7 +342,7 @@ export const RemovePosition = ({
                                 fontSize: '0.75rem',
                             }}
                         >
-                            <td>Token</td>
+                            <td></td>
                             <td>Pooled</td>
                             <td>Fees</td>
                         </tr>

--- a/packages/client/src/components/positions/remove-position.tsx
+++ b/packages/client/src/components/positions/remove-position.tsx
@@ -17,6 +17,7 @@ import { handleGasEstimationError } from 'components/add-liquidity/add-liquidity
 import { debug } from 'util/debug';
 import Sentry, { SentryError } from 'util/sentry';
 import { EthGasPrices } from '@sommelier/shared-types';
+import './positions.scss';
 
 export const RemovePosition = ({
     positionPoolStats,
@@ -50,7 +51,6 @@ export const RemovePosition = ({
 
     const doRemoveLiquidity = async (): Promise<void> => {
         // bail out if we dont have some stuff
-        console.log(position, provider, currentGasPrice);
         if (!position || !provider || !currentGasPrice) return;
 
         // get remove contract address
@@ -399,34 +399,20 @@ export const RemovePosition = ({
                 </table>
             </Box>
             <Box display='flex' textAlign='center'>
-                <Box
-                    sx={{
-                        bgcolor: 'var(--objDeep)',
-                        padding: '1rem',
-                        flexGrow: '1',
-                        borderRadius: '4px',
-                        mr: '1rem',
-                        border: '1px solid var(--objDeepAlt)',
-                    }}
-                    style={{ cursor: 'pointer' }}
+                <button
+                    className='cancel-remove'
                     onClick={() => setShowRemoveLiquidity(false)}
                 >
                     Cancel
-                </Box>
-                <Box
-                    sx={{
-                        bgcolor: 'var(--objAccent)',
-                        padding: '1rem',
-                        flexGrow: '1',
-                        borderRadius: '4px',
-                        mr: '1rem',
-                        border: '1px solid var(--objAccentAlt)',
-                    }}
-                    style={{ cursor: 'pointer' }}
+                </button>
+                &nbsp;
+                <button
+                    className='remove-position'
                     onClick={() => doRemoveLiquidity()}
+                    disabled={pendingApproval}
                 >
                     Remove
-                </Box>
+                </button>
             </Box>
         </>
     );


### PR DESCRIPTION
### Before
<img width="552" alt="Screen Shot 2021-07-12 at 11 15 32 AM" src="https://user-images.githubusercontent.com/6791048/125616645-f4e9a589-e9b7-40f6-824f-1402833c0708.png">

### After
<img width="556" alt="Screen Shot 2021-07-14 at 4 41 03 AM" src="https://user-images.githubusercontent.com/6791048/125616652-41e3b937-e389-42f9-992a-fdf995dd5424.png">
<img width="558" alt="Screen Shot 2021-07-14 at 4 57 51 AM" src="https://user-images.githubusercontent.com/6791048/125618269-60c0ce4a-921d-4090-8e39-c8923f80917c.png">
